### PR TITLE
Fixes: #2;

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,12 @@
 
 ## 1.5.0 ????/??/??
 
+## 1.4.9 2020/07/01
+
+- [2-accept-any-struct-as-option](https://github.com/pragdave/earmark/issues/2)
+    Allow client code of Earmark to replace their calls to `Earmark.as_ast` with `EarmarkParser.as_ast` w/o any
+    changes
+
 ## 1.4.8 2020/06/29
 
 This marks the first release of the parser isolated from the rest of Earmark.

--- a/lib/earmark_parser.ex
+++ b/lib/earmark_parser.ex
@@ -317,10 +317,7 @@ defmodule EarmarkParser do
   The AST is exposed in the spirit of [Floki's](https://hex.pm/packages/floki).
   """
   def as_ast(lines, options \\ %Options{})
-  def as_ast(lines, options) when is_list(options) do
-    as_ast(lines, struct(Options, options))
-  end
-  def as_ast(lines, options) do
+  def as_ast(lines, %Options{}=options) do
     context = _as_ast(lines, options)
     messages = sort_messages(context)
 
@@ -333,6 +330,12 @@ defmodule EarmarkParser do
       end
 
     {status, context.value, messages}
+  end
+  def as_ast(lines, options) when is_list(options) do
+    as_ast(lines, struct(Options, options))
+  end
+  def as_ast(lines, options) when is_map(options) do
+    as_ast(lines, struct(Options, options |> Map.delete(:__struct__) |> Enum.into([])))
   end
 
   defp _as_ast(lines, options) do

--- a/lib/earmark_parser/options.ex
+++ b/lib/earmark_parser/options.ex
@@ -35,7 +35,6 @@ defmodule EarmarkParser.Options do
             line: 1,
             # [{:error|:warning, lnb, text},...]
             messages: [],
-            plugins: %{},
             pure_links: true
 
   @type t :: %__MODULE__{

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule EarmarkParser.MixProject do
   use Mix.Project
 
-  @version "1.5.0"
+  @version "1.4.9"
   @url "https://github.com/robert_dober/earmark_parser"
 
 

--- a/test/acceptance/regressions/i002-accept-any-struct-as-option_test.exs
+++ b/test/acceptance/regressions/i002-accept-any-struct-as-option_test.exs
@@ -1,0 +1,24 @@
+defmodule Acceptance.Regressions.I002AcceptAnyStructAsOptionTest do
+  use ExUnit.Case
+
+  import EarmarkParser, only: [as_ast: 2]
+  defmodule MyStruct do
+    defstruct pure_links: false
+  end
+
+  describe "can parse with MyStruct" do
+    @markdown "see https://my.site.com"
+    test "pure_links deactivated" do
+      ast = [{"p", [], [@markdown], %{}}]
+
+      assert as_ast(@markdown, %MyStruct{}) == {:ok, ast, []}
+    end
+
+    test "or activated" do
+      ast =
+        [{"p", '', ["see ", {"a", [{"href", "https://my.site.com"}], ["https://my.site.com"], %{}}], %{}}]
+
+      assert as_ast(@markdown, %MyStruct{pure_links: true}) == {:ok, ast, []}
+    end
+  end
+end


### PR DESCRIPTION
    Allow client code of Earmark to replace their calls to `Earmark.as_ast` with `EarmarkParser.as_ast` w/o any
    changes