### PR TITLE
Support for "wikilink" style links

### DIFF
--- a/lib/earmark_parser/ast/inline.ex
+++ b/lib/earmark_parser/ast/inline.ex
@@ -109,8 +109,9 @@ defmodule EarmarkParser.Ast.Inline do
       {match1, text, href, title, link_or_img} = match
       out =
         case link_or_img do
-          :link  -> output_link(context, text, href, title, lnb)
-          :image -> render_image(text, href, title)
+          :link     -> output_link(context, text, href, title, lnb)
+          :wikilink -> output_wikilink(context, text, href, title, lnb)
+          :image    -> render_image(text, href, title)
         end
       {behead(src, match1), lnb, prepend(context, out), use_linky?}
     end
@@ -303,6 +304,10 @@ defmodule EarmarkParser.Ast.Inline do
     else
       emit("a", Enum.reverse(context2.value), href: href)
     end
+  end
+
+  defp output_wikilink(context, text, href, title, lnb) do
+    output_link(context, text, href, title, lnb)
   end
 
   defp reference_link(context, match, alt_text, id, lnb) do

--- a/lib/earmark_parser/ast/inline.ex
+++ b/lib/earmark_parser/ast/inline.ex
@@ -312,7 +312,7 @@ defmodule EarmarkParser.Ast.Inline do
   defp maybe_output_wikilink(context, text, href, title, lnb) do
     if context.options.wikilinks do
       {tag, attrs, content, meta} = output_link(context, text, href, title, lnb)
-      {tag, [{"class", "wikilink"} | attrs], content, meta}
+      {tag, attrs, content, Map.put(meta, :wikilink, true)}
     end
   end
 

--- a/lib/earmark_parser/ast/inline.ex
+++ b/lib/earmark_parser/ast/inline.ex
@@ -307,7 +307,8 @@ defmodule EarmarkParser.Ast.Inline do
   end
 
   defp output_wikilink(context, text, href, title, lnb) do
-    output_link(context, text, href, title, lnb)
+    {tag, attrs, body} = output_link(context, text, href, title, lnb)
+    {tag, [{"class", "wikilink"} | attrs], body}
   end
 
   defp reference_link(context, match, alt_text, id, lnb) do

--- a/lib/earmark_parser/ast/inline.ex
+++ b/lib/earmark_parser/ast/inline.ex
@@ -110,10 +110,13 @@ defmodule EarmarkParser.Ast.Inline do
       out =
         case link_or_img do
           :link     -> output_link(context, text, href, title, lnb)
-          :wikilink -> output_wikilink(context, text, href, title, lnb)
+          :wikilink -> maybe_output_wikilink(context, text, href, title, lnb)
           :image    -> render_image(text, href, title)
         end
-      {behead(src, match1), lnb, prepend(context, out), use_linky?}
+
+      if out do
+        {behead(src, match1), lnb, prepend(context, out), use_linky?}
+      end
     end
   end
 
@@ -306,9 +309,11 @@ defmodule EarmarkParser.Ast.Inline do
     end
   end
 
-  defp output_wikilink(context, text, href, title, lnb) do
-    {tag, attrs, content, meta} = output_link(context, text, href, title, lnb)
-    {tag, [{"class", "wikilink"} | attrs], content, meta}
+  defp maybe_output_wikilink(context, text, href, title, lnb) do
+    if context.options.wikilinks do
+      {tag, attrs, content, meta} = output_link(context, text, href, title, lnb)
+      {tag, [{"class", "wikilink"} | attrs], content, meta}
+    end
   end
 
   defp reference_link(context, match, alt_text, id, lnb) do

--- a/lib/earmark_parser/ast/inline.ex
+++ b/lib/earmark_parser/ast/inline.ex
@@ -307,8 +307,8 @@ defmodule EarmarkParser.Ast.Inline do
   end
 
   defp output_wikilink(context, text, href, title, lnb) do
-    {tag, attrs, body} = output_link(context, text, href, title, lnb)
-    {tag, [{"class", "wikilink"} | attrs], body}
+    {tag, attrs, content, meta} = output_link(context, text, href, title, lnb)
+    {tag, [{"class", "wikilink"} | attrs], content, meta}
   end
 
   defp reference_link(context, match, alt_text, id, lnb) do

--- a/lib/earmark_parser/helpers/link_parser.ex
+++ b/lib/earmark_parser/helpers/link_parser.ex
@@ -98,7 +98,17 @@ defmodule EarmarkParser.Helpers.LinkParser do
     end
   end
 
+  @wikilink_rgx ~r{\A\[\[([^\]\|]+)(?:\|([^\]]+))?\]\]\Z}
+  defp make_result(nil, _, parsed_text, :link) do
+    case Regex.run(@wikilink_rgx, parsed_text) do
+      nil -> nil
+      [_, wikilink] -> make_wikilink(parsed_text, wikilink, wikilink)
+      [_, wikilink, link_text] -> make_wikilink(parsed_text, wikilink, link_text)
+    end
+  end
+
   defp make_result(nil, _, _, _), do: nil
+
   defp make_result({parsed, url, title}, link_text, parsed_text, link_or_img) do
     {"#{parsed_text}(#{list_to_text(parsed)})", link_text, list_to_text(url), title, link_or_img}
   end
@@ -107,6 +117,10 @@ defmodule EarmarkParser.Helpers.LinkParser do
 
   defp add_title({parsed_text, url_text, _}, {parsed, inner}),
     do: {[parsed | parsed_text], url_text, inner}
+
+  defp make_wikilink(parsed_text, target, link_text) do
+    {parsed_text, String.trim(link_text), String.trim(target), nil, :wikilink}
+  end
 
   defp list_to_text(lst), do: lst |> Enum.reverse() |> Enum.join("")
 end

--- a/lib/earmark_parser/options.ex
+++ b/lib/earmark_parser/options.ex
@@ -12,6 +12,7 @@ defmodule EarmarkParser.Options do
             smartypants: true,
             footnotes: false,
             footnote_offset: 1,
+            wikilinks: false,
 
             # additional prefies for class of code blocks
             code_class_prefix: nil,
@@ -46,6 +47,7 @@ defmodule EarmarkParser.Options do
         pedantic: boolean,
         pure_links: boolean,
         smartypants: boolean,
+        wikilinks: boolean,
         timeout: maybe(number)
   }
 

--- a/test/acceptance/ast/links_images/wiki_links_test.exs
+++ b/test/acceptance/ast/links_images/wiki_links_test.exs
@@ -1,0 +1,42 @@
+defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
+  use ExUnit.Case, async: true
+  import Support.Helpers, only: [as_ast: 1, parse_html: 1]
+
+  describe "Wiki links" do
+    test "basic wiki-style link" do
+      markdown = "[[page]]"
+      html = "<p><a href=\"page\">page</a></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
+
+    test "misleading non-wiki link" do
+      markdown = "[[page]](actual_link)"
+      html = "<p><a href=\"actual_link\">[page]</a></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
+
+    test "alternate text" do
+      markdown = "[[page | My Label]]"
+      html = "<p><a href=\"page\">My Label</a></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
+
+    test "illegal urls are not Earmark's responsability" do
+      markdown = "[[A long & complex title]]"
+      html = "<p><a href=\"A long & complex title\">A long &amp; complex title</a></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
+  end
+end

--- a/test/acceptance/ast/links_images/wiki_links_test.exs
+++ b/test/acceptance/ast/links_images/wiki_links_test.exs
@@ -5,7 +5,7 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
   describe "Wiki links" do
     test "basic wiki-style link" do
       markdown = "[[page]]"
-      html = "<p><a href=\"page\">page</a></p>\n"
+      html = "<p><a class=\"wikilink\" href=\"page\">page</a></p>\n"
       ast      = parse_html(html)
       messages = []
 
@@ -23,7 +23,7 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
 
     test "alternate text" do
       markdown = "[[page | My Label]]"
-      html = "<p><a href=\"page\">My Label</a></p>\n"
+      html = "<p><a class=\"wikilink\" href=\"page\">My Label</a></p>\n"
       ast      = parse_html(html)
       messages = []
 
@@ -32,7 +32,7 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
 
     test "illegal urls are not Earmark's responsability" do
       markdown = "[[A long & complex title]]"
-      html = "<p><a href=\"A long & complex title\">A long &amp; complex title</a></p>\n"
+      html = "<p><a class=\"wikilink\" href=\"A long & complex title\">A long &amp; complex title</a></p>\n"
       ast      = parse_html(html)
       messages = []
 

--- a/test/acceptance/ast/links_images/wiki_links_test.exs
+++ b/test/acceptance/ast/links_images/wiki_links_test.exs
@@ -9,7 +9,7 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
       ast      = parse_html(html)
       messages = []
 
-      assert as_ast(markdown) == {:ok, [ast], messages}
+      assert as_ast(markdown) == {:ok, ast, messages}
     end
 
     test "misleading non-wiki link" do
@@ -18,7 +18,7 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
       ast      = parse_html(html)
       messages = []
 
-      assert as_ast(markdown) == {:ok, [ast], messages}
+      assert as_ast(markdown) == {:ok, ast, messages}
     end
 
     test "alternate text" do
@@ -27,7 +27,7 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
       ast      = parse_html(html)
       messages = []
 
-      assert as_ast(markdown) == {:ok, [ast], messages}
+      assert as_ast(markdown) == {:ok, ast, messages}
     end
 
     test "illegal urls are not Earmark's responsability" do
@@ -36,7 +36,7 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
       ast      = parse_html(html)
       messages = []
 
-      assert as_ast(markdown) == {:ok, [ast], messages}
+      assert as_ast(markdown) == {:ok, ast, messages}
     end
   end
 end

--- a/test/acceptance/ast/links_images/wiki_links_test.exs
+++ b/test/acceptance/ast/links_images/wiki_links_test.exs
@@ -1,6 +1,6 @@
 defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
   use ExUnit.Case, async: true
-  import Support.Helpers, only: [as_ast: 1, parse_html: 1]
+  import Support.Helpers, only: [as_ast: 2, parse_html: 1]
 
   describe "Wiki links" do
     test "basic wiki-style link" do
@@ -9,7 +9,16 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
       ast      = parse_html(html)
       messages = []
 
-      assert as_ast(markdown) == {:ok, ast, messages}
+      assert as_ast(markdown, wikilinks: true) == {:ok, ast, messages}
+    end
+
+    test "wikilink parsing is optional" do
+      markdown = "[[page]]"
+      html = "<p>[[page]]</p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, wikilinks: false) == {:ok, ast, messages}
     end
 
     test "misleading non-wiki link" do
@@ -18,7 +27,7 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
       ast      = parse_html(html)
       messages = []
 
-      assert as_ast(markdown) == {:ok, ast, messages}
+      assert as_ast(markdown, wikilinks: true) == {:ok, ast, messages}
     end
 
     test "alternate text" do
@@ -27,7 +36,7 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
       ast      = parse_html(html)
       messages = []
 
-      assert as_ast(markdown) == {:ok, ast, messages}
+      assert as_ast(markdown, wikilinks: true) == {:ok, ast, messages}
     end
 
     test "illegal urls are not Earmark's responsability" do
@@ -36,7 +45,7 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
       ast      = parse_html(html)
       messages = []
 
-      assert as_ast(markdown) == {:ok, ast, messages}
+      assert as_ast(markdown, wikilinks: true) == {:ok, ast, messages}
     end
   end
 end

--- a/test/acceptance/ast/links_images/wiki_links_test.exs
+++ b/test/acceptance/ast/links_images/wiki_links_test.exs
@@ -1,12 +1,12 @@
 defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
   use ExUnit.Case, async: true
-  import Support.Helpers, only: [as_ast: 2, parse_html: 1]
+  import Support.Helpers, only: [as_ast: 2, parse_html: 1, parse_html: 2]
 
   describe "Wiki links" do
     test "basic wiki-style link" do
       markdown = "[[page]]"
-      html = "<p><a class=\"wikilink\" href=\"page\">page</a></p>\n"
-      ast      = parse_html(html)
+      html = "<p><a href=\"page\">page</a></p>\n"
+      ast      = parse_html(html, &add_wikilinks_metadata/1)
       messages = []
 
       assert as_ast(markdown, wikilinks: true) == {:ok, ast, messages}
@@ -32,8 +32,8 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
 
     test "alternate text" do
       markdown = "[[page | My Label]]"
-      html = "<p><a class=\"wikilink\" href=\"page\">My Label</a></p>\n"
-      ast      = parse_html(html)
+      html = "<p><a href=\"page\">My Label</a></p>\n"
+      ast      = parse_html(html, &add_wikilinks_metadata/1)
       messages = []
 
       assert as_ast(markdown, wikilinks: true) == {:ok, ast, messages}
@@ -41,11 +41,14 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
 
     test "illegal urls are not Earmark's responsability" do
       markdown = "[[A long & complex title]]"
-      html = "<p><a class=\"wikilink\" href=\"A long & complex title\">A long &amp; complex title</a></p>\n"
-      ast      = parse_html(html)
+      html = "<p><a href=\"A long & complex title\">A long &amp; complex title</a></p>\n"
+      ast      = parse_html(html, &add_wikilinks_metadata/1)
       messages = []
 
       assert as_ast(markdown, wikilinks: true) == {:ok, ast, messages}
     end
   end
+
+  def add_wikilinks_metadata({"a", _, _}), do: %{wikilink: true}
+  def add_wikilinks_metadata(_), do: %{}
 end


### PR DESCRIPTION
(Migrated from https://github.com/pragdave/earmark/pull/377)

This is commonly used in markdown based wikis (for example, Github's wiki).