### PR TITLE
Treat - as regular text unless it's in a title

### DIFF
--- a/lib/earmark_parser/parser.ex
+++ b/lib/earmark_parser/parser.ex
@@ -179,6 +179,10 @@ defmodule EarmarkParser.Parser do
     end
   end
 
+  defp _parse([%Line.SetextUnderlineHeading{line: line, lnb: lnb, level: 2} | rest], result, options, recursive) do
+    _parse([%Line.Text{line: line, lnb: lnb} | rest], result, options, recursive)
+  end
+
   #########
   # Lists #
   #########

--- a/test/acceptance/ast/horizontal_rules_test.exs
+++ b/test/acceptance/ast/horizontal_rules_test.exs
@@ -23,6 +23,24 @@ defmodule Acceptance.Ast.HorizontalRulesTest do
       assert as_ast(markdown) == {:ok, ast, messages}
     end
 
+    test "a dash is just text" do
+      markdown = "-\nTest"
+      html     = "<p>-\nTest</p>"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown) == {:ok, ast, messages}
+    end
+
+    test "two dashes are just text" do
+      markdown = "--\nTest"
+      html     = "<p>--\nTest</p>"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown) == {:ok, ast, messages}
+    end
+
     test "not in code" do
       markdown = "    ***\n    \n     a"
       html     = "<pre><code>***\n\n a</code></pre>\n"


### PR DESCRIPTION
This fixes a bug where `"--"` parses and an empty paragraph with a warning.

The `"--"` case is [pretty well agreed upon as regular text](https://babelmark.github.io/?text=--)

The trickier one is the `"-"` case. It's [just about tied between whether it should be regular text or an empty list](https://babelmark.github.io/?text=-). I made it regular text so I could get a PR up and discussion started, but am open to making it an empty list if that would be better.