### PR TITLE
Replace another iff

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ line is given, therefor
      --------|------
      Elixir  | awesome
 
-is a table (iff `gfm_tables: true`) while
+is a table (if and only if `gfm_tables: true`) while
 
      Language|Rating
      Elixir  | awesome

--- a/lib/earmark_parser.ex
+++ b/lib/earmark_parser.ex
@@ -169,7 +169,7 @@ defmodule EarmarkParser do
        --------|------
        Elixir  | awesome
 
-  is a table (iff `gfm_tables: true`) while
+  is a table (if and only if `gfm_tables: true`) while
 
        Language|Rating
        Elixir  | awesome


### PR DESCRIPTION
This also threw me off as a non-native speaker, and then I found the following PR https://github.com/pragdave/earmark/pull/218. So this PR replaces the last `iff` with `if and only if`. 😊 