### PR TITLE
Add an option to disable inline parsing

### DIFF
--- a/lib/earmark_parser/ast/inline.ex
+++ b/lib/earmark_parser/ast/inline.ex
@@ -21,6 +21,7 @@ defmodule EarmarkParser.Ast.Inline do
   def convert(src, lnb, context), do: _convert(src, lnb, context, true)
 
   defp _convert(src, current_lnb, context, use_linky?)
+  defp _convert(src, _, %{options: %{parse_inline: false}} = context, _), do: prepend(context, src)
   defp _convert("", _, context, _), do: context
   defp _convert(src, current_lnb, context, use_linky?) do
     case _convert_next(src, current_lnb, context, use_linky?) do

--- a/lib/earmark_parser/options.ex
+++ b/lib/earmark_parser/options.ex
@@ -13,6 +13,7 @@ defmodule EarmarkParser.Options do
             footnotes: false,
             footnote_offset: 1,
             wikilinks: false,
+            parse_inline: true,
 
             # additional prefies for class of code blocks
             code_class_prefix: nil,
@@ -48,7 +49,8 @@ defmodule EarmarkParser.Options do
         pure_links: boolean,
         smartypants: boolean,
         wikilinks: boolean,
-        timeout: maybe(number)
+        timeout: maybe(number),
+        parse_inline: boolean
   }
 
   @doc false

--- a/test/acceptance/ast/paragraphs_test.exs
+++ b/test/acceptance/ast/paragraphs_test.exs
@@ -1,6 +1,6 @@
 defmodule Acceptance.Ast.ParagraphsTest do
   use ExUnit.Case, async: true
-  import Support.Helpers, only: [as_ast: 1, parse_html: 1]
+  import Support.Helpers, only: [as_ast: 1, as_ast: 2, parse_html: 1]
   import EarmarkAstDsl
 
   describe "Paragraphs" do
@@ -38,6 +38,14 @@ defmodule Acceptance.Ast.ParagraphsTest do
       messages = []
 
       assert as_ast(markdown) == {:ok, ast, messages}
+    end
+
+    test "keeps paragraph source as AST content when :parse_inline is false" do
+      markdown = "this *should* stay [unchanged]()"
+      ast      = [p([markdown])]
+      messages = []
+
+      assert as_ast(markdown, parse_inline: false) == {:ok, ast, messages}
     end
   end
 


### PR DESCRIPTION
### Use case

We use `EarmarkParser` in [Livebook](https://github.com/livebook-dev/livebook) to parse (Live)Markdown files, but we only need the AST to analyze the block structure (headings, code snippets) and then render most of it back to Markdown. When the inline content is parsed, some information is lost (for example `\` escapes, or emphasis type as in `*a _b_ c*`), which makes it hard to convert the AST back to Markdown.

### Solution

Since we don't analyze the inline content, ideally we wouldn't even parse it and keep as-is in the AST. This PR enables that by setting using a new `parse_inline: false` option.

This seems to be the minimal change that does the job, but I'm happy to discuss if you have any alternatives in mind!

### Example

```elixir
markdown = """
some \\*escaped\\* content

* item _one_
* item _two_

this *should* stay [unchanged]()
"""
```

**Regular AST**

```elixir
iex> EarmarkParser.as_ast(markdown)
{:ok,
 [
   {"p", [], ["some *escaped* content"], %{}},
   {"ul", [],
    [
      {"li", [], ["item ", {"em", [], ["one"], %{}}], %{}},
      {"li", [], ["item ", {"em", [], ["two"], %{}}], %{}}
    ], %{}},
   {"p", [],
    [
      "this ",
      {"em", [], ["should"], %{}},
      " stay ",
      {"a", [{"href", ""}], ["unchanged"], %{}}
    ], %{}}
 ], []}
```

**AST with inline content intact**

```elixir
iex> EarmarkParser.as_ast(markdown, parse_inline: false)
{:ok,
 [
   {"p", [], ["some \\*escaped\\* content"], %{}},
   {"ul", [],
    [{"li", [], ["item _one_"], %{}}, {"li", [], ["item _two_"], %{}}], %{}},
   {"p", [], ["this *should* stay [unchanged]()"], %{}}
 ], []}
```