### PR TITLE
Remove timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@
     - [To block elements](#to-block-elements)
     - [To links or images](#to-links-or-images)
 - [Limitations](#limitations)
-- [Timeouts](#timeouts)
 - [Annotations](#annotations)
   - [Annotated Paragraphs](#annotated-paragraphs)
   - [Annotated HTML elements](#annotated-html-elements)
@@ -454,19 +453,6 @@ containing an IAL-like string, as in the following example
 
         <p>mypara
          <hr /></p>
-
-## Timeouts
-
-By default, that is if the `timeout` option is not set EarmarkParser uses parallel mapping as implemented in `EarmarkParser.pmap/2`,
-which uses `Task.await` with its default timeout of 5000ms.
-
-In rare cases that might not be enough.
-
-By indicating a longer `timeout` option in milliseconds EarmarkParser will use parallel mapping as implemented in `EarmarkParser.pmap/3`,
-which will pass `timeout` to `Task.await`.
-
-In both cases one can override the mapper function with either the `mapper` option (used if and only if `timeout` is nil) or the
-`mapper_with_timeout` function (used otherwise).
 
 ## Annotations
 

--- a/lib/earmark_parser.ex
+++ b/lib/earmark_parser.ex
@@ -368,19 +368,6 @@ defmodule EarmarkParser do
           <p>mypara
            <hr /></p>
 
-  ## Timeouts
-
-  By default, that is if the `timeout` option is not set EarmarkParser uses parallel mapping as implemented in `EarmarkParser.pmap/2`,
-  which uses `Task.await` with its default timeout of 5000ms.
-
-  In rare cases that might not be enough.
-
-  By indicating a longer `timeout` option in milliseconds EarmarkParser will use parallel mapping as implemented in `EarmarkParser.pmap/3`,
-  which will pass `timeout` to `Task.await`.
-
-  In both cases one can override the mapper function with either the `mapper` option (used if and only if `timeout` is nil) or the
-  `mapper_with_timeout` function (used otherwise).
-
   ## Annotations
 
   **N.B.** this is an experimental feature from v1.4.16-pre on and might change or be removed again
@@ -504,27 +491,19 @@ defmodule EarmarkParser do
       do: to_string(version)
   end
 
-  @default_timeout_in_ms 5000
   @doc false
-  def pmap(collection, func, timeout \\ @default_timeout_in_ms) do
+  def pmap(collection, func) do
     collection
     |> Enum.map(fn item -> Task.async(fn -> func.(item) end) end)
-    |> Task.yield_many(timeout)
-    |> Enum.map(&_join_pmap_results_or_raise(&1, timeout))
+    |> Task.yield_many(:infinity)
+    |> Enum.map(&_join_pmap_results_or_raise/1)
   end
 
-  defp _join_pmap_results_or_raise(yield_tuples, timeout)
-  defp _join_pmap_results_or_raise({_task, {:ok, result}}, _timeout), do: result
+  defp _join_pmap_results_or_raise(yield_tuples)
+  defp _join_pmap_results_or_raise({_task, {:ok, result}}), do: result
 
-  defp _join_pmap_results_or_raise({task, {:error, reason}}, _timeout),
+  defp _join_pmap_results_or_raise({task, {:error, reason}}),
     do: raise(Error, "#{inspect(task)} has died with reason #{inspect(reason)}")
-
-  defp _join_pmap_results_or_raise({task, nil}, timeout),
-    do:
-      raise(
-        Error,
-        "#{inspect(task)} has not responded within the set timeout of #{timeout}ms, consider increasing it"
-      )
 end
 
 # SPDX-License-Identifier: Apache-2.0

--- a/lib/earmark_parser/options.ex
+++ b/lib/earmark_parser/options.ex
@@ -20,15 +20,11 @@ defmodule EarmarkParser.Options do
             # additional prefies for class of code blocks
             code_class_prefix: nil,
 
-            # Add possibility to specify a timeout for Task.await
-            timeout: nil,
-
             # Very internal—the callback used to perform
             # parallel rendering. Set to &Enum.map/2
             # to keep processing in process and
             # serial
             mapper: &EarmarkParser.pmap/2,
-            mapper_with_timeout: &EarmarkParser.pmap/3,
 
             # Filename and initial line number of the markdown block passed in
             # for meaningful error messages
@@ -48,7 +44,6 @@ defmodule EarmarkParser.Options do
         pure_links: boolean,
         smartypants: boolean,
         wikilinks: boolean,
-        timeout: maybe(number),
         parse_inline: boolean
   }
 
@@ -84,11 +79,7 @@ defmodule EarmarkParser.Options do
   @doc false
   # Only here we are aware of which mapper function to use!
   def get_mapper(options) do
-    if options.timeout do
-      &options.mapper_with_timeout.(&1, &2, options.timeout)
-    else
-      options.mapper
-    end
+    options.mapper
   end
 
   @doc false


### PR DESCRIPTION
Timeout is useful for dealing with external resources
but in this case the line parsing is only CPU bound,
so we can default to infinity.

If the user wants to limit the time spent parsing,
then it is probably best for them to wrap it in a task
and limit it for the whole document.