### PR TITLE
Add lookahead for fenced code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@
     - [To block elements](#to-block-elements)
     - [To links or images](#to-links-or-images)
 - [Limitations](#limitations)
-- [Timeouts](#timeouts)
 - [Annotations](#annotations)
   - [Annotated Paragraphs](#annotated-paragraphs)
   - [Annotated HTML elements](#annotated-html-elements)
@@ -454,19 +453,6 @@ containing an IAL-like string, as in the following example
 
         <p>mypara
          <hr /></p>
-
-## Timeouts
-
-By default, that is if the `timeout` option is not set EarmarkParser uses parallel mapping as implemented in `EarmarkParser.pmap/2`,
-which uses `Task.await` with its default timeout of 5000ms.
-
-In rare cases that might not be enough.
-
-By indicating a longer `timeout` option in milliseconds EarmarkParser will use parallel mapping as implemented in `EarmarkParser.pmap/3`,
-which will pass `timeout` to `Task.await`.
-
-In both cases one can override the mapper function with either the `mapper` option (used if and only if `timeout` is nil) or the
-`mapper_with_timeout` function (used otherwise).
 
 ## Annotations
 

--- a/lib/earmark_parser/helpers/footnote_handler.ex
+++ b/lib/earmark_parser/helpers/footnote_handler.ex
@@ -1,19 +1,19 @@
 defmodule EarmarkParser.Helpers.FootnoteHandler do
   @moduledoc false
 
-  alias EarmarkParser.{Block, Options}
+  alias EarmarkParser.Block
   import EarmarkParser.Message, only: [add_messages: 2]
 
   def handle_footnotes(blocks, options) do
     {footnotes, blocks} = Enum.split_with(blocks, &footnote_def?/1)
 
     {footnotes, undefined_footnotes} =
-      Options.get_mapper(options).(blocks, &find_footnote_links/1)
+      Enum.map(blocks, &find_footnote_links/1)
       |> List.flatten()
       |> get_footnote_numbers(footnotes, options)
 
     blocks = create_footnote_blocks(blocks, footnotes)
-    footnotes = Options.get_mapper(options).(footnotes, &{&1.id, &1}) |> Enum.into(Map.new())
+    footnotes = Enum.map(footnotes, &{&1.id, &1}) |> Enum.into(Map.new())
     options1 = add_messages(options, undefined_footnotes)
     {blocks, footnotes, options1}
   end

--- a/lib/earmark_parser/helpers/reparse_helpers.ex
+++ b/lib/earmark_parser/helpers/reparse_helpers.ex
@@ -8,10 +8,6 @@ defmodule EarmarkParser.Helpers.ReparseHelpers do
     Extract the verbatim text of `%EarmarkParser.Line.t` elements with less alignment so that
     it can be reparsed (as elements of footnotes or indented code)
   """
-  # In case we are inside a code block we return the verbatim text
-  def properly_indent(%{inside_code: true, line: line}, _level) do
-    line
-  end
   # Add additional spaces for any indentation past level 1
   def properly_indent(%Line.Indent{level: level, content: content}, target_level)
   when level == target_level do

--- a/lib/earmark_parser/line.ex
+++ b/lib/earmark_parser/line.ex
@@ -4,60 +4,60 @@ defmodule EarmarkParser.Line do
 
   defmodule Blank  do
     @moduledoc false
-    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, content: "", inside_code: false)
+    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, content: "")
   end
   defmodule Ruler  do
     @moduledoc false
-    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, type: "- or * or _", inside_code: false)
+    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, type: "- or * or _")
   end
 
   defmodule Heading  do
     @moduledoc false
-    defstruct(annotation: nil, ial: nil, lnb: 0, line: "", indent: -1, level: 1, content: "inline text", inside_code: false)
+    defstruct(annotation: nil, ial: nil, lnb: 0, line: "", indent: -1, level: 1, content: "inline text")
   end
 
   defmodule BlockQuote  do
     @moduledoc false
-    defstruct(annotation: nil, ial: nil, lnb: 0, line: "", indent: -1, content: "text", inside_code: false)
+    defstruct(annotation: nil, ial: nil, lnb: 0, line: "", indent: -1, content: "text")
   end
 
   defmodule Indent  do
     @moduledoc false
-    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, level: 0, content: "text", inside_code: false)
+    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, level: 0, content: "text")
   end
 
   defmodule Fence  do
     @moduledoc false
-    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, delimiter: "~ or `", language: nil, inside_code: false)
+    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, delimiter: "~ or `", language: nil)
   end
 
   defmodule HtmlOpenTag  do
     @moduledoc false
-    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, tag: "", content: "", inside_code: false)
+    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, tag: "", content: "")
   end
 
   defmodule HtmlCloseTag  do
     @moduledoc false
-    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, tag: "<... to eol", inside_code: false)
+    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, tag: "<... to eol")
   end
   defmodule HtmlComment  do
     @moduledoc false
-    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, complete: true, inside_code: false)
+    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, complete: true)
   end
 
   defmodule HtmlOneLine  do
     @moduledoc false
-    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, tag: "", content: "", inside_code: false)
+    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, tag: "", content: "")
   end
 
   defmodule IdDef  do
     @moduledoc false
-    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, id: nil, url: nil, title: nil, inside_code: false)
+    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, id: nil, url: nil, title: nil)
   end
 
   defmodule FnDef  do
     @moduledoc false
-    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, id: nil, content: "text", inside_code: false)
+    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, id: nil, content: "text")
   end
 
   defmodule ListItem do
@@ -72,28 +72,27 @@ defmodule EarmarkParser.Line do
       bullet: "* or -",
       content: "text",
       initial_indent: 0,
-      inside_code: false,
       list_indent: 0
     )
   end
 
   defmodule SetextUnderlineHeading  do
     @moduledoc false
-    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, level: 1, inside_code: false)
+    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, level: 1)
   end
 
   defmodule TableLine  do
     @moduledoc false
-    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, content: "", columns: 0, inside_code: false, is_header: false, needs_header: false)
+    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, content: "", columns: 0, is_header: false, needs_header: false)
   end
 
   defmodule Ial  do
     @moduledoc false
-    defstruct(annotation: nil, ial: nil, lnb: 0, line: "", indent: -1, attrs: "", inside_code: false, verbatim: "")
+    defstruct(annotation: nil, ial: nil, lnb: 0, line: "", indent: -1, attrs: "", verbatim: "")
   end
   defmodule Text  do
     @moduledoc false
-    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, content: "", inside_code: false)
+    defstruct(annotation: nil, lnb: 0, line: "", indent: -1, content: "")
   end
 
 

--- a/lib/earmark_parser/line_scanner.ex
+++ b/lib/earmark_parser/line_scanner.ex
@@ -79,6 +79,9 @@ defmodule EarmarkParser.LineScanner do
 
         [fence | lookahead_until_match(lines, stop, options, recursive)]
 
+      %Line.HtmlComment{complete: false} = html_comment ->
+        [html_comment | lookahead_until_match(lines, ~r/-->/u, options, recursive)]
+
       other ->
         [other | with_lookahead(lines, options, recursive)]
     end

--- a/lib/earmark_parser/line_scanner.ex
+++ b/lib/earmark_parser/line_scanner.ex
@@ -258,27 +258,21 @@ defmodule EarmarkParser.LineScanner do
         [_, leading, ial] = match
         %Line.Ial{attrs: String.trim(ial), verbatim: ial, indent: String.length(leading), line: line}
 
-      # Hmmmm in case of perf problems
-      # Assuming that text lines are the most frequent would it not boost performance (which seems to be good anyway)
-      # it would be great if we could come up with a regex that is a superset of all the regexen above and then
-      # we could match as follows
-      #
-      #       cond
-      #       nil = Regex.run(superset, line) -> %Text
-      #       ...
-      #       # all other matches from above
-      #       ...
-      #       # Catch the case were the supergx was too wide
-      #       true -> %Text
-      #
-      #
-      match = Regex.run(~r/\A (\s*) (.*)/x, line) ->
-        [_, leading, content] = match
-        %Line.Text{content: content, indent: String.length(leading), line: line}
-      true -> raise "Ooops no such line type"
+      true ->
+        create_text(line)
     end
   end
 
+  defp create_text(line) do
+    {content, indent} = count_indent(line, 0)
+    %Line.Text{content: content, indent: indent, line: line}
+  end
+
+  defp count_indent(<<space, rest::binary>>, indent) when space in [?\s, ?\t],
+    do: count_indent(rest, indent + 1)
+
+  defp count_indent(rest, indent),
+    do: {rest, indent}
 
   defp _attribute_escape(string), do:
     string

--- a/lib/earmark_parser/line_scanner.ex
+++ b/lib/earmark_parser/line_scanner.ex
@@ -4,8 +4,6 @@ defmodule EarmarkParser.LineScanner do
 
   alias EarmarkParser.{Helpers, Line, Options}
 
-  import Options, only: [get_mapper: 1]
-
   # This is the re that matches the ridiculous "[id]: url title" syntax
 
   @id_title_part ~S"""

--- a/lib/earmark_parser/line_scanner.ex
+++ b/lib/earmark_parser/line_scanner.ex
@@ -67,14 +67,14 @@ defmodule EarmarkParser.LineScanner do
     case type_of(line_lnb, options, recursive) do
       %Line.Fence{delimiter: delimiter, indent: indent} = fence ->
         stop =
-          # We should stop on another code block, any open/close html tag,
+          # We should stop on another code block, any close html tag,
           # or on less indent if there is any indentation.
           case indent do
             0 ->
-              ~r/\A(\s*)(#{delimiter})\s*([^`\s]*)\s*\z|\A<\/?([-\w]+?)(?:\s.*)?>/u
+              ~r/\A(\s*)(#{delimiter})\s*([^`\s]*)\s*\z|\A(\s{0,3})<\/([-\w]+?)>/u
 
             _ ->
-              ~r/\A(\s*)(#{delimiter})\s*([^`\s]*)\s*\z|\A<\/?([-\w]+?)(?:\s.*)?>|\A\s{#{indent - 1}}.+\z/u
+              ~r/\A(\s*)(#{delimiter})\s*([^`\s]*)\s*\z|\A(\s{0,3})<\/([-\w]+?)>|\A\s{#{indent - 1}}.+\z/u
           end
 
         [fence | lookahead_until_match(lines, stop, options, recursive)]

--- a/lib/earmark_parser/options.ex
+++ b/lib/earmark_parser/options.ex
@@ -20,16 +20,6 @@ defmodule EarmarkParser.Options do
             # additional prefies for class of code blocks
             code_class_prefix: nil,
 
-            # Add possibility to specify a timeout for Task.await
-            timeout: nil,
-
-            # Very internal—the callback used to perform
-            # parallel rendering. Set to &Enum.map/2
-            # to keep processing in process and
-            # serial
-            mapper: &EarmarkParser.pmap/2,
-            mapper_with_timeout: &EarmarkParser.pmap/3,
-
             # Filename and initial line number of the markdown block passed in
             # for meaningful error messages
             file: "<no file>",
@@ -48,7 +38,6 @@ defmodule EarmarkParser.Options do
         pure_links: boolean,
         smartypants: boolean,
         wikilinks: boolean,
-        timeout: maybe(number),
         parse_inline: boolean
   }
 
@@ -80,16 +69,6 @@ defmodule EarmarkParser.Options do
     end
   end
   def normalize(options), do: struct(__MODULE__, options) |> normalize()
-
-  @doc false
-  # Only here we are aware of which mapper function to use!
-  def get_mapper(options) do
-    if options.timeout do
-      &options.mapper_with_timeout.(&1, &2, options.timeout)
-    else
-      options.mapper
-    end
-  end
 
   @doc false
   def plugin_for_prefix(options, plugin_name) do

--- a/lib/earmark_parser/parser.ex
+++ b/lib/earmark_parser/parser.ex
@@ -222,7 +222,7 @@ defmodule EarmarkParser.Parser do
     {code_lines, rest} = Enum.split_while(rest, fn (line) ->
       !match?(%Line.Fence{delimiter: ^delimiter, language: _}, line)
     end)
-    rest = if length(rest) == 0, do: rest, else: tl(rest)
+    rest = if rest == [], do: rest, else: tl(rest)
     code = (for line <- code_lines, do: line.line)
     _parse(rest, [ %Block.Code{lines: code, language: language, lnb: lnb} | result ], options, recursive)
   end
@@ -259,7 +259,7 @@ defmodule EarmarkParser.Parser do
     {html_lines, rest} = Enum.split_while(lines, fn (line) ->
       !(line.line =~ ~r/-->/)
     end)
-    {html_lines, rest} = if length(rest) == 0 do
+    {html_lines, rest} = if rest == [] do
       {html_lines, rest}
     else
       {html_lines ++ [ hd(rest) ], tl(rest)}

--- a/lib/earmark_parser/types.ex
+++ b/lib/earmark_parser/types.ex
@@ -6,7 +6,7 @@ defmodule EarmarkParser.Types do
     quote do
       @type token  :: {atom, String.t}
       @type tokens :: list(token)
-      @type numbered_line :: %{required(:line) => String.t, required(:lnb) => number, optional(:inside_code) => String.t}
+      @type numbered_line :: %{required(:line) => String.t, required(:lnb) => number}
       @type message_type :: :warning | :error
       @type message :: {message_type, number, String.t}
       @type maybe(t) :: t | nil

--- a/test/acceptance/ast/comment_test.exs
+++ b/test/acceptance/ast/comment_test.exs
@@ -27,6 +27,14 @@ defmodule Acceptance.Ast.CommentTest do
 
       assert as_ast(markdown) == {:ok, [ast], messages}
     end
+
+    test "what about the fenced closing" do
+      markdown = "<!-- Hello\n```elixir\n World -->garbish"
+      ast      = {:comment, [], [" Hello", "```elixir", " World "], %{comment: true}}
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
   end
 end
 # SPDX-License-Identifier: Apache-2.0

--- a/test/acceptance/ast/html/block/annotated_block_test.exs
+++ b/test/acceptance/ast/html/block/annotated_block_test.exs
@@ -71,6 +71,15 @@ defmodule Acceptance.Ast.Html.Block.AnnotatedBlockTest do
 
       assert as_ast(markdown, annotations: @annotations) == {:ok, ast, messages}
     end
+
+    test "even non-closed block elements" do
+      markdown = "<div>\n```elixir\ndefmodule Mine do\n</div>"
+      ast = [vtag("div", ["```elixir", "defmodule Mine do"])]
+      messages = []
+
+      assert as_ast(markdown, annotations: @annotations) == {:ok, ast, messages}
+    end
+
     test "even block elements" do
       markdown = "<div>\n```elixir\ndefmodule Mine do\n```\n</div>*:at_the_end"
       ast = [vtag_annotated("div", ["```elixir", "defmodule Mine do", "```"], "*:at_the_end")]

--- a/test/acceptance/ast/list_and_inline_code_test.exs
+++ b/test/acceptance/ast/list_and_inline_code_test.exs
@@ -63,7 +63,7 @@ defmodule Acceptance.Ast.ListAndInlineCodeTest do
       assert as_ast(markdown) == {:ok, ast, messages}
     end
 
-    test "more aligned fence is part of the inlinde code block" do
+    test "more aligned fence is part of the inline code block" do
       markdown = "  1. one\n    ~~~elixir\n    defmodule\n        ~~~"
       ast      = [tag("ol", tag("li", ["one", tag("pre", tag("code", ["defmodule"], [{"class", "elixir"}]))]))]
       messages = []

--- a/test/functional/scanner/line_type_test.exs
+++ b/test/functional/scanner/line_type_test.exs
@@ -245,14 +245,12 @@ defmodule Functional.Scanner.LineTypeTest do
       {"[^1]: bar baz",
        %EarmarkParser.Line.Text{
          content: "[^1]: bar baz",
-         inside_code: false,
          line: "[^1]: bar baz",
          lnb: 42
        }, nil},
       {"[^1]: bar baz",
        %EarmarkParser.Line.Text{
          content: "[^1]: bar baz",
-         inside_code: false,
          line: "[^1]: bar baz",
          lnb: 42
        }, "annotated"},
@@ -360,12 +358,11 @@ defmodule Functional.Scanner.LineTypeTest do
 
   not_ial_test_cases =
   [
-    {"--", %Line.Text{annotation: nil, indent: 0, inside_code: false, line: "--{:.not-ial}", lnb: 1905, content: "--{:.not-ial}"}},
+    {"--", %Line.Text{annotation: nil, indent: 0, line: "--{:.not-ial}", lnb: 1905, content: "--{:.not-ial}"}},
     {"* * *", %Line.ListItem{
               annotation: nil,
               ial: nil,
               indent: 0,
-              inside_code: false,
               line: "* * *{:.not-ial}",
               lnb: 1905,
               type: :ul,


### PR DESCRIPTION
Livebook can store outputs in markdown, which can lead
to pretty long code fence tags.

Earmark currently parses all lines, even if they belong to
code fences or html comments. This pull request adds
a small amount of lookahead for those two constructs.
With this, the problematic example report given to us
parses in 10ms, with no timeouts: https://raw.githubusercontent.com/mathiasose/advent-2021/main/aoc.livemd

The lookahead also removes the parallel mapping,
which I have verified to not be efficient in Elixir code
bases, as most lines tend to be short.

I also sneaked in some small optimizations, such as
`length(rest) == 0` which is linear to the size of
`rest` being replaced by `rest == []`.