### PR TITLE
Address regression on closing tags inside fenced blocks

### DIFF
--- a/lib/earmark_parser/line_scanner.ex
+++ b/lib/earmark_parser/line_scanner.ex
@@ -66,14 +66,11 @@ defmodule EarmarkParser.LineScanner do
     case type_of(line_lnb, options, recursive) do
       %Line.Fence{delimiter: delimiter, indent: indent} = fence ->
         stop =
-          # We should stop on another code block, any close html tag,
-          # or on less indent if there is any indentation.
+          # We should stop on another code block or
+          # on less indent if there is any indentation.
           case indent do
-            0 ->
-              ~r/\A(\s*)(#{delimiter})\s*([^`\s]*)\s*\z|\A(\s{0,3})<\/([-\w]+?)>/u
-
-            _ ->
-              ~r/\A(\s*)(#{delimiter})\s*([^`\s]*)\s*\z|\A(\s{0,3})<\/([-\w]+?)>|\A\s{#{indent - 1}}\S/u
+            0 -> ~r/\A(\s*)(#{delimiter})\s*([^`\s]*)\s*\z/u
+            _ -> ~r/\A(\s*)(#{delimiter})\s*([^`\s]*)\s*\z|\A\s{#{indent - 1}}\S/u
           end
 
         [fence | lookahead_until_match(lines, stop, options, recursive)]

--- a/lib/earmark_parser/line_scanner.ex
+++ b/lib/earmark_parser/line_scanner.ex
@@ -64,15 +64,8 @@ defmodule EarmarkParser.LineScanner do
 
   defp with_lookahead([line_lnb | lines], options, recursive) do
     case type_of(line_lnb, options, recursive) do
-      %Line.Fence{delimiter: delimiter, indent: indent} = fence ->
-        stop =
-          # We should stop on another code block or
-          # on less indent if there is any indentation.
-          case indent do
-            0 -> ~r/\A(\s*)(#{delimiter})\s*([^`\s]*)\s*\z/u
-            _ -> ~r/\A(\s*)(#{delimiter})\s*([^`\s]*)\s*\z|\A\s{#{indent - 1}}\S/u
-          end
-
+      %Line.Fence{delimiter: delimiter, indent: 0} = fence when recursive ->
+        stop = ~r/\A(#{delimiter})\s*([^`\s]*)\s*\z/u
         [fence | lookahead_until_match(lines, stop, options, recursive)]
 
       %Line.HtmlComment{complete: false} = html_comment ->

--- a/test/acceptance/ast/fenced_code_blocks_test.exs
+++ b/test/acceptance/ast/fenced_code_blocks_test.exs
@@ -69,11 +69,11 @@
     end
 
     test "in list" do
-      markdown = "- a\n- ```\n  b\n\n\n ```\n- c\n"
+      markdown = "- a\n- ```\n  b\n\n\n ```\n c\n- d\n"
       ast = [{ "ul", [],
         [{"li", [], ["a"], %{}},
-         {"li", [], [{"pre", [], [{"code", [], ["  b\n\n"], %{}}], %{}}], %{}},
-         {"li", [], ["c"], %{}}
+         {"li", [], [{"pre", [], [{"code", [], ["  b\n\n"], %{}}], %{}}, "c"], %{}},
+         {"li", [], ["d"], %{}}
        ], %{}}]
 
       messages = []
@@ -92,6 +92,17 @@
       messages = []
 
       assert as_ast(markdown) == {:ok, ast, messages}
+    end
+
+    @indented """
+    ```
+        ```
+    ```
+    """
+    test "fenced with indented" do
+      expected = [pre_code("    ```")]
+
+      assert as_ast(@indented) == {:ok, expected, []}
     end
   end
 end

--- a/test/acceptance/ast/fenced_code_blocks_test.exs
+++ b/test/acceptance/ast/fenced_code_blocks_test.exs
@@ -81,6 +81,18 @@
       assert as_ast(markdown) == {:ok, ast, messages}
     end
 
+    test "fenced with tag" do
+      markdown = "```\n\"<nav>\n  <ul></ul>\n</nav>\"\n```\n\n## Header\n\nbar"
+      ast = [
+        {"pre", [], [{"code", [], ["\"<nav>\n  <ul></ul>\n</nav>\""], %{}}], %{}},
+        {"h2", [], ["Header"], %{}},
+        {"p", [], ["bar"], %{}}
+      ]
+
+      messages = []
+
+      assert as_ast(markdown) == {:ok, ast, messages}
+    end
   end
 end
 

--- a/test/acceptance/ast/html/block/annotated_block_test.exs
+++ b/test/acceptance/ast/html/block/annotated_block_test.exs
@@ -75,9 +75,9 @@ defmodule Acceptance.Ast.Html.Block.AnnotatedBlockTest do
     test "even non-closed block elements" do
       markdown = "<div>\n```elixir\ndefmodule Mine do\n</div>"
       ast = [vtag("div", ["```elixir", "defmodule Mine do"])]
-      messages = [{:warning, 1, "Failed to find closing <div>"}]
+      messages = []
 
-      assert as_ast(markdown, annotations: @annotations) == {:error, ast, messages}
+      assert as_ast(markdown, annotations: @annotations) == {:ok, ast, messages}
     end
 
     test "even block elements" do

--- a/test/acceptance/ast/html/block/annotated_block_test.exs
+++ b/test/acceptance/ast/html/block/annotated_block_test.exs
@@ -75,9 +75,9 @@ defmodule Acceptance.Ast.Html.Block.AnnotatedBlockTest do
     test "even non-closed block elements" do
       markdown = "<div>\n```elixir\ndefmodule Mine do\n</div>"
       ast = [vtag("div", ["```elixir", "defmodule Mine do"])]
-      messages = []
+      messages = [{:warning, 1, "Failed to find closing <div>"}]
 
-      assert as_ast(markdown, annotations: @annotations) == {:ok, ast, messages}
+      assert as_ast(markdown, annotations: @annotations) == {:error, ast, messages}
     end
 
     test "even block elements" do


### PR DESCRIPTION
This slightly changes the behaviour of invalid Markdown
where a tag is opened and then a fenced code block that
is never closed is within. The previous behaviour already
different from GitHub. We keep the same AST but not we
return warnings.

Closes #77.