### PR TITLE
bugfix prevent no function clause in MapSet.union/2

### DIFF
--- a/lib/earmark_parser/context.ex
+++ b/lib/earmark_parser/context.ex
@@ -53,17 +53,24 @@ defmodule EarmarkParser.Context do
          %__MODULE__{referenced_footnote_ids: new} = context2
        ) do
     context_ = _merge_messages(context1, context2)
-    %{context_| referenced_footnote_ids: MapSet.union(orig, new)}
+    %{context_ | referenced_footnote_ids: MapSet.union(orig, new)}
   end
 
   defp _merge_messages(context, context_or_messages)
+
   defp _merge_messages(context, %__MODULE__{options: %Options{messages: messages}}) do
     _merge_messages(context, messages)
   end
-  defp _merge_messages(context, messages) do
-    %{context | options: %{context.options|messages: MapSet.union(context.options.messages, messages)}}
-  end
 
+  defp _merge_messages(context, messages) do
+    %{
+      context
+      | options: %{
+          context.options
+          | messages: MapSet.union(MapSet.new(context.options.messages), MapSet.new(messages))
+        }
+    }
+  end
 
   defp _prepend(ctxt, []), do: ctxt
 

--- a/test/acceptance/regressions/i064_no_function_clause_mapset_union_test.ex
+++ b/test/acceptance/regressions/i064_no_function_clause_mapset_union_test.ex
@@ -1,0 +1,21 @@
+defmodule Acceptance.Regressions.I064NoFunctionClauseMapSetUnionTest do
+  use ExUnit.Case
+
+  import EarmarkParser, only: [as_ast: 2]
+
+  describe "can merge_messages" do
+    test "prevent MapSet.union/2 error passing no MapSet.t()" do
+      markdown = """
+      ```
+        content
+      ```
+      """
+
+      options = %{messages: []}
+
+      ast = [{"pre", [], [{"code", [], ["  content"], %{}}], %{}}]
+
+      assert as_ast(markdown, options) == {:ok, ast, []}
+    end
+  end
+end


### PR DESCRIPTION
The `MapSet.union/2` expected two `MapSet` data type, but receiving an List
data type. To prevent this error, passing both data to `MapSet.new/1`.

```
Elixir 1.13.2 (compiled with Erlang/OTP 24)
Erlang 24.2
```

The issue:

I was working with [Surface.Catalogue](https://github.com/surface-ui/surface_catalogue), and I was creating some `Surface.Components`, when I open the catalogue on my browser, I received this error here:

```elixir
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in MapSet.union/2
        (elixir 1.13.2) lib/map_set.ex:372: MapSet.union([], [])
        (earmark_parser 1.4.19) lib/earmark_parser/context.ex:66: EarmarkParser.Context._merge_messages/2
        (earmark_parser 1.4.19) lib/earmark_parser/context.ex:55: EarmarkParser.Context._merge_contexts/2
        (earmark_parser 1.4.19) lib/earmark_parser/context.ex:47: EarmarkParser.Context.prepend/3
        (earmark_parser 1.4.19) lib/earmark_parser/ast_renderer.ex:23: EarmarkParser.AstRenderer._render/3
        (earmark_parser 1.4.19) lib/earmark_parser.ex:494: EarmarkParser.as_ast/2
        (earmark 1.4.19) lib/earmark/internal.ex:42: Earmark.Internal.as_html/2
        (surface_catalogue 0.3.0) lib/surface/catalogue/markdown.ex:20: Surface.Catalogue.Markdown.to_html/2
```

I put the `IO.inspect/2` inside the `EarmarkParser.Context._merge_messages/2` to see the `context` and the `message`:

```elixir
context: %EarmarkParser.Context{
  footnotes: %{},
  links: %{},
  options: %EarmarkParser.Options{
    annotations: nil,
    breaks: false,
    code_class_prefix: "language-",
    file: nil,
    footnote_offset: 1,
    footnotes: false,
    gfm: true,
    gfm_tables: false,
    line: 1,
    messages: [],
    parse_inline: true,
    pedantic: false,
    pure_links: true,
    renderer: EarmarkParser.HtmlRenderer,
    smartypants: false,
    timeout: nil,
    wikilinks: false
  },
  referenced_footnote_ids: #MapSet<[]>,
  rules: %{
    br: ~r/^ {2,}\n(?!\s*$)/,
    escape: ~r/^\\([\\`*\{}\[\]()\#+\-.!_>~|])/,
    footnote: ~r/\z\A/,
    strikethrough: ~r/^~~(?=\S)([\s\S]*?\S)~~/,
    text: ~r/^[\s\S]+?(?=[\\<!\[_*`~]|https?:\/\/| \{2,}\n|$)/,
    url: ~r/^(https?:\/\/[^\s<]+[^<.,:;\"\')\]\s])/
  },
  value: []
}
messages: []
```

To prevent this error, when I try to pass both data as a List, it was necessarily too passing into `MapSet.new/1` first, before passing to [MapSet.union/2](https://hexdocs.pm/elixir/MapSet.html#union/2).