### PR TITLE
Correct pure link regex to reject invalid characters

### DIFF
--- a/lib/earmark_parser/helpers/pure_link_helpers.ex
+++ b/lib/earmark_parser/helpers/pure_link_helpers.ex
@@ -4,7 +4,7 @@ defmodule EarmarkParser.Helpers.PureLinkHelpers do
   import EarmarkParser.Helpers.StringHelpers, only: [betail: 2]
   import EarmarkParser.Helpers.AstHelpers, only: [render_link: 1]
 
-  @pure_link_rgx ~r{\A(\s*)(\()?(https?://[[:alnum:]"'*@:+-_{\}()/.%\#&]*)}u
+  @pure_link_rgx ~r{\A(\s*)(\()?(https?://[-[:alnum:]"'*@:+_{\}()/.%\#&?=\[\]~!,;]*)}u
 
   def convert_pure_link(src) do
     case Regex.run(@pure_link_rgx, src) do

--- a/test/earmark_helpers_tests/pure_link_helper_test.exs
+++ b/test/earmark_helpers_tests/pure_link_helper_test.exs
@@ -59,6 +59,11 @@ defmodule EarmarkParser.Helpers.TestPureLinkHelpers do
       result = convert_pure_link("(http://www.google.com/search?q=business")
       assert result == {"(", 1} 
     end
-  end
 
+    test "invalid charecters should not be part of the link" do
+      result = convert_pure_link("https://a.link.com<br/>")
+      expected = {tag("a",  "https://a.link.com", href:  "https://a.link.com"), 18}
+      assert result == expected
+    end
+  end
 end


### PR DESCRIPTION
Regex is using character range `+-_` which would match any character between ascii character range of 43 (`+`) to 65 (`_`), which includes invalid characters like `<` and `>`

ref: https://www.rfc-editor.org/rfc/rfc3986#section-2

Fixes #90 