### PR TITLE
Fix pure link parsing issues and make it closer to GFM

### DIFF
--- a/lib/earmark_parser/helpers/pure_link_helpers.ex
+++ b/lib/earmark_parser/helpers/pure_link_helpers.ex
@@ -1,53 +1,84 @@
 defmodule EarmarkParser.Helpers.PureLinkHelpers do
   @moduledoc false
 
-  import EarmarkParser.Helpers.StringHelpers, only: [betail: 2]
-  import EarmarkParser.Helpers.AstHelpers, only: [render_link: 1]
+  import EarmarkParser.Helpers.AstHelpers, only: [render_link: 2]
 
-  @pure_link_rgx ~r{\A(\s*)(\()?(https?://[-[:alnum:]"'*@:+_{\}()/.%\#&?=\[\]~!,;]*)}u
+  @pure_link_rgx ~r{
+    \A                       # begining of the string
+    (\s*)                    # zero or more spaces
+    (                        # capture complete link
+      (?:https?://|www\.)    # must match prefix
+      [^\s<>]*               # any characters except space, <, >
+      [^\s<>?!.,:*_~]        # any character except space, <, >, and other few symbols
+    )
+  }ux
+
+   def test(src) do
+     Regex.run(@pure_link_rgx, src)
+   end
 
   def convert_pure_link(src) do
     case Regex.run(@pure_link_rgx, src) do
-      [_match, spaces, "", link_text] -> reparse_link(spaces, link_text)
-      [_match, spaces, _, link_text]  -> remove_trailing_closing_parens(spaces, link_text)
-      _ -> nil
-      end
-  end
+      [_match, spaces, link_text] ->
+        if String.ends_with?(link_text, ")") do
+          remove_trailing_closing_parens(spaces, link_text)
+        else
+          make_result(spaces, link_text)
+        end
 
-  defp determine_ending_parens_by_count(leading_spaces, prefix, surplus_on_closing_parens) do
-    graphemes = String.graphemes(prefix)
-    open_parens_count = Enum.count(graphemes, &(&1 == "("))
-    close_parens_count = Enum.count(graphemes, &(&1 == ")"))
-    delta = open_parens_count - close_parens_count
-    take = min(delta, surplus_on_closing_parens)
-    needed =
-    :lists.duplicate(max(0, take), ")")
-    |> Enum.join
-    link = render_link(prefix <> needed)
-    ast =
-      case leading_spaces do
-        "" -> link
-        _ -> [leading_spaces, link]
-      end
-    {ast, String.length(prefix) + String.length(leading_spaces) + max(0,take)}
+      _ ->
+        nil
+    end
   end
 
   @split_at_ending_parens ~r{(.*?)(\)*)\z}
   defp remove_trailing_closing_parens(leading_spaces, link_text) do
-    [_, _prefix, suffix] = Regex.run(@split_at_ending_parens, link_text)
-    case suffix do
-      "" -> {"(", String.length(leading_spaces) + 1}
-      _  -> case convert_pure_link(betail(link_text, 1)) do
-        {link, length} -> {["(", link, ")"], length + 2}
-        _ -> nil
+    [_, link_text, trailing_parens] = Regex.run(@split_at_ending_parens, link_text)
+    trailing_paren_count = String.length(trailing_parens)
+
+    # try to balance parens from the rhs
+    unbalanced_count = balance_parens(String.reverse(link_text), trailing_paren_count)
+    balanced_parens = String.slice(trailing_parens, 0, trailing_paren_count - unbalanced_count)
+
+    make_result(leading_spaces, link_text <> balanced_parens)
+  end
+
+  defp make_result(leading_spaces, link_text) do
+    link =
+      if String.starts_with?(link_text, "www.") do
+        render_link("http://" <> link_text, link_text)
+      else
+        render_link(link_text, link_text)
       end
+
+    if leading_spaces == "" do
+      {link, String.length(link_text)}
+    else
+      {[leading_spaces, link], String.length(leading_spaces) + String.length(link_text)}
     end
   end
 
-  defp reparse_link(leading_spaces, link_text) do
-    [_, prefix, suffix] = Regex.run(@split_at_ending_parens, link_text)
-    nof_closing_parens = String.length(suffix)
-    determine_ending_parens_by_count(leading_spaces, prefix, nof_closing_parens)
+  # balance parens and return unbalanced *trailing* paren count
+  defp balance_parens(reverse_text, trailing_count, non_trailing_count \\ 0)
+
+  defp balance_parens(<<>>, trailing_paren_count, _non_trailing_count), do: trailing_paren_count
+
+  defp balance_parens(_reverse_text, 0, _non_trailing_count), do: 0
+
+  defp balance_parens(")" <> rest, trailing_paren_count, non_trailing_count) do
+    balance_parens(rest, trailing_paren_count, non_trailing_count + 1)
   end
 
+  defp balance_parens("(" <> rest, trailing_paren_count, non_trailing_count) do
+    # non-trailing paren must be balanced before trailing paren
+    if non_trailing_count > 0 do
+      balance_parens(rest, trailing_paren_count, non_trailing_count - 1)
+    else
+      balance_parens(rest, trailing_paren_count - 1, non_trailing_count)
+    end
+  end
+
+  defp balance_parens(<<_::utf8,rest::binary>>, trailing_paren_count, non_trailing_count) do
+    balance_parens(rest, trailing_paren_count, non_trailing_count)
+  end
 end

--- a/test/acceptance/ast/links_images/pure_links_test.exs
+++ b/test/acceptance/ast/links_images/pure_links_test.exs
@@ -82,7 +82,7 @@ defmodule Acceptance.Ast.LinksImages.PureLinksTest do
 
     test "imbrication" do
       markdown = "(http://my.org/robert(is_best)"
-      ast      = p(["(", tag("a", ["http://my.org/robert(is_best"],[{"href", "http://my.org/robert(is_best"}]), ")"])
+      ast      = p(["(", tag("a", ["http://my.org/robert(is_best)"],[{"href", "http://my.org/robert(is_best)"}])])
       messages = []
 
       assert as_ast(markdown) == {:ok, [ast], messages}
@@ -111,6 +111,31 @@ defmodule Acceptance.Ast.LinksImages.PureLinksTest do
 
       assert as_ast(markdown) == {:ok, [ast], messages}
     end
+
+    test "trailing parens are not part of it, at least not all" do
+      markdown = "(https://a.link.com))"
+      ast      = p(["(", tag("a",  "https://a.link.com", href:  "https://a.link.com"), "))"])
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
+
+    test "closing parens can match opening parens at the end" do
+      markdown = "(http://www.google.com/search?q=business)"
+      ast      = p(["(", tag("a", "http://www.google.com/search?q=business", href: "http://www.google.com/search?q=business"), ")"])
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
+
+    test "opening parens w/o closing parens do not match" do
+      markdown = "(http://www.google.com/search?q=business"
+      ast      = p(["(", tag("a", "http://www.google.com/search?q=business", href: "http://www.google.com/search?q=business")])
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
+
   end
 
   describe "more acceptable characters (was: regression #350)" do
@@ -147,6 +172,26 @@ defmodule Acceptance.Ast.LinksImages.PureLinksTest do
     test "two query params" do
       markdown = "https://example.com?foo=1&bar=2"
       ast      = p(tag("a", markdown, [{"href", markdown}]))
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
+  end
+
+  describe "matching parenthesis" do
+    test "match trailing closing parenthesis with the opening parenthesis in the link" do
+      markdown = "(http://github.com/(foo)"
+      ast      = p(["(", tag("a", ["http://github.com/(foo)"], [{"href", "http://github.com/(foo)"}])])
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
+  end
+
+  describe "unicode charecters" do
+    test "support non alpha-numeric unicode charecters" do
+      markdown = "http://github.com?foo=😀"
+      ast      = p([tag("a", ["http://github.com?foo=😀"], [{"href", "http://github.com?foo=#{URI.encode("😀")}"}])])
       messages = []
 
       assert as_ast(markdown) == {:ok, [ast], messages}

--- a/test/earmark_helpers_tests/pure_link_helper_test.exs
+++ b/test/earmark_helpers_tests/pure_link_helper_test.exs
@@ -19,13 +19,6 @@ defmodule EarmarkParser.Helpers.TestPureLinkHelpers do
       assert result == expected
     end
 
-    test "trailing parens are not part of it, at least not all" do
-      #                          0....+....1....+....2.
-      result = convert_pure_link("(https://a.link.com))")
-      expected = {["(", tag("a",  "https://a.link.com", href:  "https://a.link.com"), ")"], 20}
-      assert result == expected
-    end
-
 
     test "however opening parens are" do
       #                           0....+....1....+...
@@ -48,21 +41,33 @@ defmodule EarmarkParser.Helpers.TestPureLinkHelpers do
       assert result == expected
     end
 
-    test "closing parens can match opening parens at the end" do
-      #                          0....+....1....+....2....+....3....+....4.
-      result = convert_pure_link("(http://www.google.com/search?q=business)")
-      expected = {["(", tag("a", "http://www.google.com/search?q=business", href: "http://www.google.com/search?q=business"), ")"], 41}
-      assert result == expected
-    end
-
-    test "opening parens w/o closing parens do not match" do
-      result = convert_pure_link("(http://www.google.com/search?q=business")
-      assert result == {"(", 1} 
-    end
-
     test "invalid charecters should not be part of the link" do
       result = convert_pure_link("https://a.link.com<br/>")
       expected = {tag("a",  "https://a.link.com", href:  "https://a.link.com"), 18}
+      assert result == expected
+    end
+
+    test "trailing parens should be unaffected by unbalanced parens inside" do
+      result = convert_pure_link("https://a.link.com/q=foo)+(ok))")
+      expected = {tag("a",  "https://a.link.com/q=foo)+(ok)", href:  "https://a.link.com/q=foo)+(ok)"), 30}
+      assert result == expected
+    end
+
+    test "recognize www. prefix" do
+      result = convert_pure_link("www.github.com")
+      expected = {tag("a",  "www.github.com", href:  "http://www.github.com"), 14}
+      assert result == expected
+    end
+
+    test "must start with http:// or https:// or www." do
+      result = convert_pure_link("ftp://foo.com")
+      expected = nil
+      assert result == expected
+    end
+
+    test "trailing dot must not be part of the link" do
+      result = convert_pure_link("www.github.com.")
+      expected = {tag("a",  "www.github.com", href:  "http://www.github.com"), 14}
       assert result == expected
     end
   end


### PR DESCRIPTION
This change is addressing multiple pure-link parsing issue whilst make the implementation closer to GFM [spec](https://github.github.com/gfm/#autolinks-extension-). Please check the new tests for the cases.

The logic of handling braces around pure-link is removed, since it is already handled elsewhere. Moved the associated tests from pure_link_helper_test.exs to acceptance test file.

Note that this is still not handling all the cases from GFM spec such as email links and semicolon at the end 