### PR TITLE
Preserve newlines inside HTML code

### DIFF
--- a/lib/earmark_parser/helpers/html_parser.ex
+++ b/lib/earmark_parser/helpers/html_parser.ex
@@ -65,7 +65,7 @@ defmodule EarmarkParser.Helpers.HtmlParser do
     tag_tpl |> Tuple.append(Enum.reverse(lines)) |> Tuple.append(@verbatim)
   end
   defp _parse_rest([last_line], {tag, _}=tag_tpl, lines) do
-    case Regex.run(~r{\A</#{tag}>\s*(.*)}, last_line) do
+    case Regex.run(~r{\A\s*</#{tag}>\s*(.*)}, last_line) do
       nil         -> tag_tpl |> Tuple.append(Enum.reverse([last_line|lines])) |> Tuple.append(@verbatim)
       [_, ""]     -> tag_tpl |> Tuple.append(Enum.reverse(lines)) |> Tuple.append(@verbatim)
       [_, suffix] -> [tag_tpl |> Tuple.append(Enum.reverse(lines)) |> Tuple.append(@verbatim), suffix]

--- a/test/acceptance/ast/html/block/annotated_block_test.exs
+++ b/test/acceptance/ast/html/block/annotated_block_test.exs
@@ -12,7 +12,7 @@ defmodule Acceptance.Ast.Html.Block.AnnotatedBlockTest do
         "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n"
 
       ast = [
-        {"table", [], ["  <tr>", "    <td>", "           hi", "    </td>", "  </tr>"], @verbatim},
+        {"table", [], ["  <tr>\n    <td>\n           hi\n    </td>\n  </tr>"], @verbatim},
         p("okay.")
       ]
 
@@ -25,7 +25,7 @@ defmodule Acceptance.Ast.Html.Block.AnnotatedBlockTest do
         "<table> *: my_table\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n"
 
       ast = [
-        {"table", [], ["  <tr>", "    <td>", "           hi", "    </td>", "  </tr>"], annotated(@verbatim, "*: my_table")},
+        {"table", [], ["  <tr>\n    <td>\n           hi\n    </td>\n  </tr>"], annotated(@verbatim, "*: my_table")},
         p("okay.")
       ]
 
@@ -36,14 +36,15 @@ defmodule Acceptance.Ast.Html.Block.AnnotatedBlockTest do
 
     test "div (ine?) -- non-regression" do
       markdown = "<div>\n  *hello*\n         <foo><a>\n</div>\n"
-      ast = [vtag("div", ["  *hello*", "         <foo><a>"])]
+      ast = [vtag("div", ["  *hello*\n         <foo><a>"])]
       messages = []
 
       assert as_ast(markdown, annotations: @annotations) == {:ok, ast, messages}
     end
+
     test "div (ine?)" do
       markdown = "<div>*:my-div\n  *hello*\n         <foo><a>\n</div>\n"
-      ast = [vtag_annotated("div", ["  *hello*", "         <foo><a>"], "*:my-div")]
+      ast = [vtag_annotated("div", ["  *hello*\n         <foo><a>"], "*:my-div")]
       messages = []
 
       assert as_ast(markdown, annotations: @annotations) == {:ok, ast, messages}
@@ -66,7 +67,7 @@ defmodule Acceptance.Ast.Html.Block.AnnotatedBlockTest do
 
     test "even block elements -- non-regression" do
       markdown = "<div>\n```elixir\ndefmodule Mine do\n```\n</div>"
-      ast = [vtag("div", ["```elixir", "defmodule Mine do", "```"])]
+      ast = [vtag("div", ["```elixir\ndefmodule Mine do\n```"])]
       messages = []
 
       assert as_ast(markdown, annotations: @annotations) == {:ok, ast, messages}
@@ -74,7 +75,7 @@ defmodule Acceptance.Ast.Html.Block.AnnotatedBlockTest do
 
     test "even non-closed block elements" do
       markdown = "<div>\n```elixir\ndefmodule Mine do\n</div>"
-      ast = [vtag("div", ["```elixir", "defmodule Mine do"])]
+      ast = [vtag("div", ["```elixir\ndefmodule Mine do"])]
       messages = []
 
       assert as_ast(markdown, annotations: @annotations) == {:ok, ast, messages}
@@ -82,7 +83,7 @@ defmodule Acceptance.Ast.Html.Block.AnnotatedBlockTest do
 
     test "even block elements" do
       markdown = "<div>\n```elixir\ndefmodule Mine do\n```\n</div>*:at_the_end"
-      ast = [vtag_annotated("div", ["```elixir", "defmodule Mine do", "```"], "*:at_the_end")]
+      ast = [vtag_annotated("div", ["```elixir\ndefmodule Mine do\n```"], "*:at_the_end")]
       messages = []
 
       assert as_ast(markdown, annotations: @annotations) == {:ok, ast, messages}
@@ -260,7 +261,7 @@ defmodule Acceptance.Ast.Html.Block.AnnotatedBlockTest do
 
     test "this is not closing" do
       markdown = "<div>\nline\n</hello></div>"
-      ast = [{"div", [], ["line", "</hello></div>"], @verbatim}]
+      ast = [{"div", [], ["line\n</hello></div>"], @verbatim}]
       messages = [{:warning, 1, "Failed to find closing <div>"}]
 
       assert as_ast(markdown, annotations: @annotations) == {:error, ast, messages}
@@ -268,7 +269,7 @@ defmodule Acceptance.Ast.Html.Block.AnnotatedBlockTest do
 
     test "therefore the div continues" do
       markdown = "<div>\nline\n</hello></div>\n</div>"
-      ast = [vtag("div", ["line", "</hello></div>"])]
+      ast = [vtag("div", ["line\n</hello></div>"])]
       messages = []
 
       assert as_ast(markdown, annotations: @annotations) == {:ok, ast, messages}

--- a/test/acceptance/ast/html/block/unannotated_block_test.exs
+++ b/test/acceptance/ast/html/block/unannotated_block_test.exs
@@ -11,7 +11,7 @@ defmodule Acceptance.Ast.Html.Block.UnannotatedBlockTest do
         "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n"
 
       ast = [
-        {"table", [], ["  <tr>", "    <td>", "           hi", "    </td>", "  </tr>"], @verbatim},
+        {"table", [], ["  <tr>\n    <td>\n           hi\n    </td>\n  </tr>"], @verbatim},
         p("okay.")
       ]
 
@@ -22,7 +22,22 @@ defmodule Acceptance.Ast.Html.Block.UnannotatedBlockTest do
 
     test "div (ine?)" do
       markdown = "<div>\n  *hello*\n         <foo><a>\n</div>\n"
-      ast = [vtag("div", ["  *hello*", "         <foo><a>"])]
+      ast = [vtag("div", ["  *hello*\n         <foo><a>"])]
+      messages = []
+
+      assert as_ast(markdown) == {:ok, ast, messages}
+    end
+
+    test "code" do
+      markdown = """
+      <code>
+      > hello
+
+      > world
+      </code>
+      """
+
+      ast = [vtag("code", ["> hello\n\n> world"])]
       messages = []
 
       assert as_ast(markdown) == {:ok, ast, messages}
@@ -38,7 +53,7 @@ defmodule Acceptance.Ast.Html.Block.UnannotatedBlockTest do
 
     test "even block elements" do
       markdown = "<div>\n```elixir\ndefmodule Mine do\n```\n</div>"
-      ast = [vtag("div", ["```elixir", "defmodule Mine do", "```"])]
+      ast = [vtag("div", ["```elixir\ndefmodule Mine do\n```"])]
       messages = []
 
       assert as_ast(markdown) == {:ok, ast, messages}
@@ -216,7 +231,7 @@ defmodule Acceptance.Ast.Html.Block.UnannotatedBlockTest do
 
     test "this is not closing" do
       markdown = "<div>\nline\n</hello></div>"
-      ast = [{"div", [], ["line", "</hello></div>"], @verbatim}]
+      ast = [{"div", [], ["line\n</hello></div>"], @verbatim}]
       messages = [{:warning, 1, "Failed to find closing <div>"}]
 
       assert as_ast(markdown) == {:error, ast, messages}
@@ -224,7 +239,7 @@ defmodule Acceptance.Ast.Html.Block.UnannotatedBlockTest do
 
     test "therefore the div continues" do
       markdown = "<div>\nline\n</hello></div>\n</div>"
-      ast = [vtag("div", ["line", "</hello></div>"])]
+      ast = [vtag("div", ["line\n</hello></div>"])]
       messages = []
 
       assert as_ast(markdown) == {:ok, ast, messages}


### PR DESCRIPTION
This slightly changes the HTML representation of the underlying nodes.

Before, this html:

```html
<code>
pre
post
</code>
```

Would come out as:

    {:code, [], ["pre", "post"]}

And now it comes out as:

    {:code, [], ["pre\npost"]}

While both representations are correct, the second representation where all text nodes are collapsed into one is more common:

```elixir
iex>  Floki.parse_fragment("<code>foo\nbar</code>")
{:ok, [{"code", [], ["foo\nbar"]}]}
```
