### PR TITLE
Apply fence lookahead optimisation for top-level code blocks

### DIFF
--- a/lib/earmark_parser/line_scanner.ex
+++ b/lib/earmark_parser/line_scanner.ex
@@ -265,8 +265,8 @@ defmodule EarmarkParser.LineScanner do
 
   defp _with_lookahead([line_lnb | lines], options, recursive) do
     case type_of(line_lnb, options, recursive) do
-      %Line.Fence{delimiter: delimiter, indent: 0} = fence when recursive ->
-        stop = ~r/\A (?: #{delimiter} ) \s* ([^`\s]*) \s* \z/xu
+      %Line.Fence{delimiter: delimiter, indent: 0} = fence ->
+        stop = ~r/\A (\s*) (?: #{delimiter} ) \s* ([^`\s]*) \s* \z/xu
         [fence | _lookahead_until_match(lines, stop, options, recursive)]
 
       %Line.HtmlComment{complete: false} = html_comment ->

--- a/test/acceptance/ast/html/block/annotated_block_test.exs
+++ b/test/acceptance/ast/html/block/annotated_block_test.exs
@@ -75,10 +75,10 @@ defmodule Acceptance.Ast.Html.Block.AnnotatedBlockTest do
 
     test "even non-closed block elements" do
       markdown = "<div>\n```elixir\ndefmodule Mine do\n</div>"
-      ast = [vtag("div", ["```elixir\ndefmodule Mine do"])]
-      messages = []
+      ast = [vtag("div", ["```elixir\ndefmodule Mine do\n</div>"])]
+      messages = [{:warning, 1, "Failed to find closing <div>"}]
 
-      assert as_ast(markdown, annotations: @annotations) == {:ok, ast, messages}
+      assert as_ast(markdown, annotations: @annotations) == {:error, ast, messages}
     end
 
     test "even block elements" do


### PR DESCRIPTION
The optimisation was introduced in #70 then modified in #79, but with the latter it no longer applies to top-level code blocks (which is primarily what we need), this brings it back.