### PR TITLE
Allow valueless attributes in html tags

### DIFF
--- a/lib/earmark_parser/helpers/html_parser.ex
+++ b/lib/earmark_parser/helpers/html_parser.ex
@@ -18,11 +18,12 @@ defmodule EarmarkParser.Helpers.HtmlParser do
   # Parse One Tag
   # -------------
 
-  @attribute ~r{\A ([-\w]+) = (["']) (.*?) \2 \s*}x
+  @attribute ~r{\A ([-\w]+) (= (["']) (.*?) \3 \s*)?}x
   defp _parse_atts(string, tag, atts) do
     case Regex.run(@attribute, string) do
-      [all, name, _delim, value] -> _parse_atts(behead(string, all), tag, [{name, value}|atts])
-      _                          -> _parse_tag_tail(string, tag, atts)
+      [all, name, _delim, _v, value] -> _parse_atts(behead(string, all), tag, [{name, value}|atts])
+      [all, name]                    -> _parse_atts(behead(string, all), tag, [{name, name}|atts])
+      _                              -> _parse_tag_tail(string, tag, atts)
     end
   end
 

--- a/test/acceptance/ast/html/one_line/unannotated_oneline_test.exs
+++ b/test/acceptance/ast/html/one_line/unannotated_oneline_test.exs
@@ -19,6 +19,13 @@ defmodule Acceptance.Ast.Html.Oneline.UnannotatedOnelineTest do
 
       assert as_ast(markdown) == {:ok, ast, messages}
     end
+
+    test "valueless attributes" do
+      markdown = "<input type=\"checkbox\" checked></input>"
+      ast = [vtag("input", nil, type: "checkbox", checked: "checked")]
+      messages = []
+
+      assert as_ast(markdown) == {:ok, ast, messages}
+    end
   end
 end
-


### PR DESCRIPTION
HTML allows attributes without values, in which case they're treated like so:

```
<input checked>
```

is interpreted as

```
<input checked="checked">
```

My change unfortunately breaks another test case, which wants to swallow attributes missing quotes. This will now interpret the example
```
<div class=my-div></div>
```
as 
```
<div class="class"></div>
```

I couldn't find a good solution using regex, maybe you have an idea? Browsers will permissively treat this as
```
<div class="my-div"></div>
```
but HTML parsing is hard :)


(as an aside, Earmark should treat `input` tags as void elements)