### PR TITLE
implement sub and sup syntax

### DIFF
--- a/lib/earmark_parser/ast/inline.ex
+++ b/lib/earmark_parser/ast/inline.ex
@@ -55,6 +55,8 @@ defmodule EarmarkParser.Ast.Inline do
       converter_for_strikethrough_gfm: &converter_for_strikethrough_gfm/1,
       converter_for_strong: &converter_for_strong/1,
       converter_for_em: &converter_for_em/1,
+      converter_for_sub: &converter_for_sub/1,
+      converter_for_sup: &converter_for_sup/1,
       converter_for_code: &converter_for_code/1,
       converter_for_br: &converter_for_br/1,
       converter_for_inline_ial: &converter_for_inline_ial/1,
@@ -207,6 +209,20 @@ defmodule EarmarkParser.Ast.Inline do
   defp converter_for_em({src, _, _, _} = conv_tuple) do
     if match = Regex.run(@emphasis_rgx, src) do
       _converter_for_simple_tag(conv_tuple, match, "em")
+    end
+  end
+
+  @sub_rgx ~r{\A~(?=\S)([\s\S]*?\S)~}
+  def converter_for_sub({src, _, _, _} = conv_tuple) do
+    if match = Regex.run(@sub_rgx, src) do
+      _converter_for_simple_tag(conv_tuple, match, "sub")
+    end
+  end
+
+  @sup_rgx ~r{\A\^(?=\S)([\s\S]*?\S)\^}
+  def converter_for_sup({src, _, _, _} = conv_tuple) do
+    if match = Regex.run(@sup_rgx, src) do
+      _converter_for_simple_tag(conv_tuple, match, "sup")
     end
   end
 

--- a/lib/earmark_parser/context.ex
+++ b/lib/earmark_parser/context.ex
@@ -111,7 +111,7 @@ defmodule EarmarkParser.Context do
           escape: ~r{^\\([\\`*\{\}\[\]()\#+\-.!_>~|])},
           url: ~r{^(https?:\/\/[^\s<]+[^<.,:;\"\')\]\s])},
           strikethrough: ~r{^~~(?=\S)([\s\S]*?\S)~~},
-          text: ~r{^[\s\S]+?(?=[\\<!\[_*`~]|https?://| \{2,\}\n|$)}
+          text: ~r{^[\s\S]+?(?=[\\<!\[_*`~^]|https?://| \{2,\}\n|$)}
         ]
 
         if options.breaks do

--- a/test/acceptance/ast/horizontal_rules_test.exs
+++ b/test/acceptance/ast/horizontal_rules_test.exs
@@ -2,7 +2,7 @@ defmodule Acceptance.Ast.HorizontalRulesTest do
   use ExUnit.Case, async: true
   import Support.Helpers, only: [as_ast: 1, parse_html: 1]
   import EarmarkAstDsl
-  
+
   describe "Horizontal rules" do
 
     test "thick, thin & medium" do
@@ -76,6 +76,22 @@ defmodule Acceptance.Ast.HorizontalRulesTest do
       assert as_ast(markdown) == {:ok, ast, messages}
     end
 
+    test "subindex" do
+      markdown = "This is H~2~O, only water"
+      ast      = [p(["This is H", tag("sub", "2"), "O, only water"])]
+      messages = []
+
+      assert as_ast(markdown) == {:ok, ast, messages}
+    end
+
+    test "superindex" do
+      markdown = "we get O(n^2^)"
+      ast      = [p(["we get O(n", tag("sup", "2"), ")"])]
+      messages = []
+
+      assert as_ast(markdown) == {:ok, ast, messages}
+    end
+
     test "in lists" do
       markdown = "- foo\n***\n- bar\n"
       html     = "<ul>\n<li>foo</li>\n</ul>\n<hr class=\"thick\"/>\n<ul>\n<li>bar</li>\n</ul>\n"
@@ -103,7 +119,7 @@ defmodule Acceptance.Ast.HorizontalRulesTest do
     end
   end
 
-  describe "Horizontal Rules and IAL" do 
+  describe "Horizontal Rules and IAL" do
     test "add a class and an id" do
       markdown = "***\n{: .custom}\n---\n{: .klass #id42}\n___\n{: hello=world}\n"
       html     = "<hr class=\"custom thick\" />\n<hr class=\"klass thin\" id=\"id42\" />\n<hr class=\"medium\" hello=\"world\" />\n"


### PR DESCRIPTION
This PR tries to solve #108 adding a syntax for sub and super indexes:

Subindex:
```
The component of the water is H^2^O.
```

Superindex:
```
This is the complexity of O(n^2^).
```