### PR TITLE
Don't wrap labeled wikilinks in p tags

### DIFF
--- a/lib/earmark_parser/line_scanner.ex
+++ b/lib/earmark_parser/line_scanner.ex
@@ -180,7 +180,7 @@ defmodule EarmarkParser.LineScanner do
           line: line
         }
 
-      Regex.run(~r/\A (\s*) .* \s \| \s /x, line) ->
+      line |> String.replace(~r/\[\[ .*? \]\]/x, "") |> String.match?(~r/\A (\s*) .* \s \| \s /x) ->
         columns = _split_table_columns(line)
 
         %Line.TableLine{
@@ -191,7 +191,7 @@ defmodule EarmarkParser.LineScanner do
           line: line
         }
 
-      options.gfm_tables && Regex.run(~r/\A (\s*) .* \| /x, line) ->
+      options.gfm_tables && line |> String.replace(~r/\[\[ .*? \]\]/x, "") |> String.match?(~r/\A (\s*) .* \| /x) ->
         columns = _split_table_columns(line)
 
         %Line.TableLine{

--- a/test/acceptance/ast/links_images/wiki_links_test.exs
+++ b/test/acceptance/ast/links_images/wiki_links_test.exs
@@ -47,6 +47,24 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
 
       assert as_ast(markdown, wikilinks: true) == {:ok, ast, messages}
     end
+
+    test "links in a list don't get wrapped in a p tag" do
+      markdown = "* Test: [[page | My Label]]"
+      html = "<ul><li>Test: <a href=\"page\">My Label</a></li></ul>\n"
+      ast      = parse_html(html, &add_wikilinks_metadata/1)
+      messages = []
+
+      assert as_ast(markdown, wikilinks: true) == {:ok, ast, messages}
+    end
+
+    test "links in a list don't get wrapped in a p tag when using GFM" do
+      markdown = "* Test: [[page | My Label]]"
+      html = "<ul><li>Test: <a href=\"page\">My Label</a></li></ul>\n"
+      ast      = parse_html(html, &add_wikilinks_metadata/1)
+      messages = []
+
+      assert as_ast(markdown, wikilinks: true, gfm_tables: true) == {:ok, ast, messages}
+    end
   end
 
   def add_wikilinks_metadata({"a", _, _}), do: %{wikilink: true}


### PR DESCRIPTION
The line scanner was recognizing the | in a wikilink label as a table column separator. This eventually still got turned into a link, but by then, it was already wrapped in a Para block.

To fix this, eat anything wrapped in double square brackets before looking for the table regex.

@sionide21 here you go, thx again