### PR TITLE
Allow hash sign in header

### DIFF
--- a/lib/earmark_parser/line_scanner.ex
+++ b/lib/earmark_parser/line_scanner.ex
@@ -80,7 +80,7 @@ defmodule EarmarkParser.LineScanner do
       lt_four? && Regex.run(~r/\A (?:_\s?){3,} \z/x, content) ->
         %Line.Ruler{type: "_", indent: indent, line: line}
 
-      match = Regex.run(~R/^(#{1,6})\s+(?|([^#]+)#*\s*$|(.*))/u, stripped_line) ->
+      match = Regex.run(~R/^(#{1,6})\s+(?|(.*?)\s*#*\s*$|(.*))/u, stripped_line) ->
         [_, level, heading] = match
 
         %Line.Heading{

--- a/test/acceptance/ast/atx_headers_test.exs
+++ b/test/acceptance/ast/atx_headers_test.exs
@@ -85,6 +85,29 @@ defmodule Acceptance.Ast.AtxHeadersTest do
       assert as_ast(markdown) == {:ok, [ast], messages}
     end
 
+    test "closing headers can get creative" do
+      markdown = "### foo######\n"
+      ast      = tag("h3", "foo")
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
+
+    test "hash can still be used in a header" do
+      markdown = "# C# #\n"
+      ast      = tag("h1", "C#")
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
+
+    test "closing header with hash" do
+      markdown = "# C# (language)#\n"
+      ast      = tag("h1", "C# (language)")
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
   end
 end
 


### PR DESCRIPTION
At the moment, parser has hard time parsing notorious `C#` header:

```elixir
# this is valid I guess
iex(1)> EarmarkParser.as_ast("### C#")               
{:ok, [{"h3", [], ["C"], %{}}], []}
# this looks like a bug
iex(2)> EarmarkParser.as_ast("### C# (language)#")
{:ok, [{"h3", [], ["C# (language)#"], %{}}], []}
```
It doesn't look like there is an agreement on how to enable it, but there definitely should be some way to do this! In this PR I altered the regex a bit so that force closing the header would "escape" the content:
```elixir
iex(7)> EarmarkParser.as_ast("### C# #") 
{:ok, [{"h3", [], ["C#"], %{}}], []}
```