### PR TITLE
Support unquoted attrs without space before closing >

### DIFF
--- a/lib/earmark_parser/helpers/html_parser.ex
+++ b/lib/earmark_parser/helpers/html_parser.ex
@@ -19,7 +19,7 @@ defmodule EarmarkParser.Helpers.HtmlParser do
   # -------------
 
   @quoted_attr ~r{\A ([-\w]+) \s* = \s* (["']) (.*?) \2 \s*}x
-  @unquoted_attr ~r{\A ([-\w]+) (?: \s* = \s* ([^&\s]*))? \s*}x
+  @unquoted_attr ~r{\A ([-\w]+) (?: \s* = \s* ([^&\s>]*))? \s*}x
   defp _parse_atts(string, tag, atts) do
     case Regex.run(@quoted_attr, string) do
       [all, name, _delim, value] -> _parse_atts(behead(string, all), tag, [{name, value}|atts])

--- a/test/acceptance/ast/html/one_line/attributes_test.exs
+++ b/test/acceptance/ast/html/one_line/attributes_test.exs
@@ -39,6 +39,22 @@ defmodule Acceptance.Ast.Html.Oneline.AttributesTest do
 
       assert as_ast(markdown) == {:ok, ast, messages}
     end
+
+    test "without space before > in non-void element" do
+      markdown = "Before\n\n<span class=test>inside</span>\n\nAfter"
+      ast = [p(["Before"]), vtag("span", ["inside"], class: "test"), p(["After"])]
+      messages = []
+
+      assert as_ast(markdown) == {:ok, ast, messages}
+    end
+
+    test "without space before > in void element" do
+      markdown = "Before\n\n<img src=image.png>\n\nAfter"
+      ast = [p(["Before"]), vtag("img", [], src: "image.png"), p(["After"])]
+      messages = []
+
+      assert as_ast(markdown) == {:ok, ast, messages}
+    end
   end
 
   describe "valueless attributes" do


### PR DESCRIPTION
I had a real-world Markdown document that looked like this:

```markdown
...

<meta name=”referrer” content=”no-referrer”>

...
```

Note that the `meta` tag's attributes are not using reqular quotes, but left/right double quotes (`&ldquo;` and `&rdquo;` in HTML speak). The attributes are therefore unquoted.

Earmark would raise an error:

```
     ** (CaseClauseError) no case clause matching: nil
     code: assert Training.extract_snippet(input) == expected
     stacktrace:
       (earmark_parser 1.4.26) lib/earmark_parser/helpers/html_parser.ex:44: EarmarkParser.Helpers.HtmlParser._parse_tag_tail/3
       (earmark_parser 1.4.26) lib/earmark_parser/helpers/html_parser.ex:10: EarmarkParser.Helpers.HtmlParser.parse_html/1
       (earmark_parser 1.4.26) lib/earmark_parser/ast/renderer/html_renderer.ex:18: EarmarkParser.Ast.Renderer.HtmlRenderer.render_html_oneline/3
       (earmark_parser 1.4.26) lib/earmark_parser/ast_renderer.ex:23: EarmarkParser.AstRenderer._render/3
       (earmark_parser 1.4.26) lib/earmark_parser.ex:526: EarmarkParser.as_ast/2
       (earmark 1.4.27) lib/earmark/internal.ex:42: Earmark.Internal.as_html/2
```

This is bad Markdown/HTML, but i think Earmark should handle it anyway.

I narrowed the issue down, and found out that it would fail without a space before the ending `>` in the tag. Something as simple as this would fail:

```
iex(21)> Earmark.as_html!("<img src=image.png>")
** (CaseClauseError) no case clause matching: nil
    (earmark_parser 1.4.26) lib/earmark_parser/helpers/html_parser.ex:44: EarmarkParser.Helpers.HtmlParser._parse_tag_tail/3
...
```

I attempted to fix the issue here by making the unquoted attribute scanning regex stop when encountering a `>`.