### PR TITLE
Avoid deprecated negative slice in Elixir v1.16-dev

### DIFF
--- a/lib/earmark_parser/helpers/string_helpers.ex
+++ b/lib/earmark_parser/helpers/string_helpers.ex
@@ -6,7 +6,8 @@ defmodule EarmarkParser.Helpers.StringHelpers do
   Remove the leading part of a string
   """
   def behead(str, ignore) when is_integer(ignore) do
-    String.slice(str, ignore..-1)
+    {_pre, post} = String.split_at(str, ignore)
+    post
   end
 
   def behead(str, leading_string) do


### PR DESCRIPTION
There is still a long time for Elixir v1.16
but since I run on the edge, I thought I
would send a PR.

Another solution for the problem is to
use `String.slice(string, ignore..-1//1)`
but that would require Elixir v1.12. The
version in this PR supports earlier
versions too.