### PR TITLE
Add optional support for math syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
     - [Pure links](#pure-links)
     - [Wikilinks...](#wikilinks)
   - [Sub and Sup HTML Elements](#sub-and-sup-html-elements)
+  - [Mathematical expressions](#mathematical-expressions)
   - [Github Flavored Markdown](#github-flavored-markdown)
     - [Strike Through](#strike-through)
     - [GFM Tables](#gfm-tables)
@@ -168,6 +169,34 @@ But by specifying `sub_sup: true`
 ```elixir
     iex(10)> EarmarkParser.as_ast("H~2~O or a^n^ + b^n^ = c^n^", sub_sup: true)
     {:ok, [{"p", [], ["H", {"sub", [], ["2"], %{}}, "O or a", {"sup", [], ["n"], %{}}, " + b", {"sup", [], ["n"], %{}}, " = c", {"sup", [], ["n"], %{}}], %{}}], []}
+```
+
+### Mathematical expressions
+
+> Note: math syntax within Markdown is not standardized, so this option is a subject to change in future releases.
+
+This feature is not enabled by default but can be enabled with the option `math: true`.
+
+When enabled, LaTeX formatted math can be written within Markdown. For more information, see [LaTeX/Mathematics](https://en.wikibooks.org/wiki/LaTeX/Mathematics) in Wikibooks.
+
+#### Inline expressions
+
+Inline-style expression can be written by surrounding the expression with dollar symbols (`$`).
+
+```elixir
+    iex> EarmarkParser.as_ast("$x = 1$", math: true)
+    {:ok, [{"p", [], [{"code", [{"class", "math-inline"}], ["x = 1"], %{line: 1}}], %{}}], []}
+```
+
+There must be no space between `$` and the surrounded expression. If you want to use a dollar sign in the same line as a math expression, you can escape the dollar with backslash (`\\$`).
+
+#### Expressions as blocks
+
+Display-style expression can be written by surrounding the expression with two dollar signs (`$$`).
+
+```elixir
+    iex> EarmarkParser.as_ast("$$x = 1$$", math: true)
+    {:ok, [{"p", [], [{"code", [{"class", "math-display"}], ["x = 1"], %{line: 1}}], %{}}], []}
 ```
 
 ### Github Flavored Markdown

--- a/lib/earmark_parser.ex
+++ b/lib/earmark_parser.ex
@@ -111,6 +111,30 @@ defmodule EarmarkParser do
       iex(10)> EarmarkParser.as_ast("H~2~O or a^n^ + b^n^ = c^n^", sub_sup: true)
       {:ok, [{"p", [], ["H", {"sub", [], ["2"], %{}}, "O or a", {"sup", [], ["n"], %{}}, " + b", {"sup", [], ["n"], %{}}, " = c", {"sup", [], ["n"], %{}}], %{}}], []}
 
+  ### Mathematical expressions
+
+  > Note: math syntax within Markdown is not standardized, so this option is a subject to change in future releases.
+
+  This feature is not enabled by default but can be enabled with the option `math: true`.
+
+  When enabled, LaTeX formatted math can be written within Markdown. For more information, see [LaTeX/Mathematics](https://en.wikibooks.org/wiki/LaTeX/Mathematics) in Wikibooks.
+
+  #### Inline expressions
+
+  Inline-style expression can be written by surrounding the expression with dollar symbols (`$`).
+
+      iex> EarmarkParser.as_ast("$x = 1$", math: true)
+      {:ok, [{"p", [], [{"code", [{"class", "math-inline"}], ["x = 1"], %{line: 1}}], %{}}], []}
+
+  There must be no space between `$` and the surrounded expression. If you want to use a dollar sign in the same line as a math expression, you can escape the dollar with backslash (`\\$`).
+
+  #### Expressions as blocks
+
+  Display-style expression can be written by surrounding the expression with two dollar signs (`$$`).
+
+      iex> EarmarkParser.as_ast("$$x = 1$$", math: true)
+      {:ok, [{"p", [], [{"code", [{"class", "math-display"}], ["x = 1"], %{line: 1}}], %{}}], []}
+
   ### Github Flavored Markdown
 
   GFM is supported by default, however as GFM is a moving target and all GFM extension do not make sense in a general context, EarmarkParser does not support all of it, here is a list of what is supported:

--- a/lib/earmark_parser/context.ex
+++ b/lib/earmark_parser/context.ex
@@ -110,16 +110,22 @@ defmodule EarmarkParser.Context do
       else
         ""
       end
+    math =
+      if options.math do
+        "$"
+      else
+        ""
+      end
     rule_updates =
       if options.gfm do
         rules = [
-          text: ~r{^[\s\S]+?(?=~~|[\\<!\[_*`#{subsup}]|https?://| \{2,\}\n|$)}
+          text: ~r{^[\s\S]+?(?=~~|[\\<!\[_*`#{math}#{subsup}]|https?://| \{2,\}\n|$)}
         ]
 
         if options.breaks do
           break_updates = [
             br: ~r{^ *\n(?!\s*$)},
-            text: ~r{^[\s\S]+?(?=~~|[\\<!\[_*`#{subsup}]|https?://| *\n|$)}
+            text: ~r{^[\s\S]+?(?=~~|[\\<!\[_*`#{math}#{subsup}]|https?://| *\n|$)}
           ]
 
           Keyword.merge(rules, break_updates)

--- a/lib/earmark_parser/helpers/ast_helpers.ex
+++ b/lib/earmark_parser/helpers/ast_helpers.ex
@@ -30,7 +30,7 @@ defmodule EarmarkParser.Helpers.AstHelpers do
     [{t, merge_attrs(a, atts), c, m}|tags]
   end
   def augment_tag_with_ial([], _atts) do
-    [] 
+    []
   end
 
   @doc false
@@ -39,6 +39,15 @@ defmodule EarmarkParser.Helpers.AstHelpers do
       ["" | String.split(prefix || "")]
       |> Enum.map(fn pfx -> "#{pfx}#{language}" end)
       {"class", classes |> Enum.join(" ")}
+  end
+
+  @doc false
+  def math_inline(text, lnb) do
+    emit("code", text, [class: "math-inline"], %{line: lnb})
+  end
+
+  def math_display(text, lnb) do
+    emit("code", text, [class: "math-display"], %{line: lnb})
   end
 
   @doc false

--- a/lib/earmark_parser/options.ex
+++ b/lib/earmark_parser/options.ex
@@ -24,6 +24,7 @@ defmodule EarmarkParser.Options do
             messages: MapSet.new([]),
             pure_links: true,
             sub_sup: false,
+            math: false,
 
             # deprecated
             pedantic: false,
@@ -57,7 +58,7 @@ defmodule EarmarkParser.Options do
             # deprecated
             pedantic: boolean(),
             smartypants: boolean(),
-            timeout: nil | non_neg_integer() 
+            timeout: nil | non_neg_integer()
 
   }
 

--- a/test/acceptance/ast/math_test.exs
+++ b/test/acceptance/ast/math_test.exs
@@ -1,0 +1,217 @@
+defmodule Acceptance.Ast.MathTest do
+  use ExUnit.Case, async: true
+  import Support.Helpers, only: [as_ast: 1, as_ast: 2, parse_html: 1]
+
+  test "ignored when :math is disabled" do
+    markdown = "foo $x = 1$ bar $$x = 1$$"
+    html     = "<p>foo $x = 1$ bar $$x = 1$$</p>\n"
+    ast      = parse_html(html)
+    messages = []
+
+    assert as_ast(markdown) == {:ok, ast, messages}
+  end
+
+  describe "math inline" do
+    test "base case" do
+      markdown = "foo $x = 1$"
+      html     = "<p>foo <code class=\"math-inline\">x = 1</code></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "with surrounding characters" do
+      markdown = "foo$x = 1$bar"
+      html     = "<p>foo<code class=\"math-inline\">x = 1</code>bar</p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "ignored when where are spaces" do
+      markdown = "foo $ x = 1$ bar $x = 1 $ baz $ x = 1 $"
+      html     = "<p>foo $ x = 1$ bar $x = 1 $ baz $ x = 1 $</p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "accepts inner newline" do
+      markdown = "foo $x\ny$"
+      html     = "<p>foo <code class=\"math-inline\">x\ny</code></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "ignored when the first dollar is escaped" do
+      markdown = "foo \\$x = 1$"
+      html     = "<p>foo $x = 1$</p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "keeps escaped inner dollar" do
+      markdown = "foo $x \\$ y$"
+      html     = "<p>foo <code class=\"math-inline\">x \\$ y</code></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "keeps backslash" do
+      markdown = "foo $\\frac{1}{2}$"
+      html     = "<p>foo <code class=\"math-inline\">\\frac{1}{2}</code></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "ignores inner markdown syntax" do
+      markdown = "foo $x *y* x$"
+      html     = "<p>foo <code class=\"math-inline\">x *y* x</code></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "ignores empty content" do
+      markdown = "foo $$"
+      html     = "<p>foo $$</p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "inside list" do
+      markdown = "* $x = 1$"
+      html     = "<ul><li><code class=\"math-inline\">x = 1</code></li></ul>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+  end
+
+  describe "math display" do
+    test "base case" do
+      markdown = "foo $$x = 1$$"
+      html     = "<p>foo <code class=\"math-display\">x = 1</code></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "with surrounding characters" do
+      markdown = "foo$$x = 1$$bar"
+      html     = "<p>foo<code class=\"math-display\">x = 1</code>bar</p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "accepts spaces on delimiter boundaries" do
+      markdown = "foo $$ x = 1 $$"
+      html     = "<p>foo <code class=\"math-display\">x = 1</code></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "accepts inner newlines" do
+      markdown = "foo $$\nx\ny\n$$"
+      html     = "<p>foo <code class=\"math-display\">x\ny</code></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "ignored when the first dollars are escaped" do
+      markdown = "foo \\$\\$x = 1$$"
+      html     = "<p>foo $$x = 1$$</p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "keeps escaped inner dollar" do
+      markdown = "foo $$x \\$ y$$"
+      html     = "<p>foo <code class=\"math-display\">x \\$ y</code></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "keeps backslash" do
+      markdown = "foo $$\\frac{1}{2}$$"
+      html     = "<p>foo <code class=\"math-display\">\\frac{1}{2}</code></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "ignores inner markdown syntax" do
+      markdown = "foo $$x *y* x$$"
+      html     = "<p>foo <code class=\"math-display\">x *y* x</code></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "ignores empty content" do
+      markdown = "foo $$$$"
+      html     = "<p>foo $$$$</p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "inside list" do
+      markdown = "* $$x = 1$$"
+      html     = "<ul><li><code class=\"math-display\">x = 1</code></li></ul>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "standalone paragraph" do
+      markdown = "$$\nx = 1\n$$"
+      html     = "<p><code class=\"math-display\">x = 1</code></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+
+    test "ignored when there is an empty line (separate paragraphs)" do
+      markdown = "$$x\n\ny$$"
+      html     = "<p>$$x</p><p>y$$</p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown, math: true) == {:ok, ast, messages}
+    end
+  end
+end
+
+# SPDX-License-Identifier: Apache-2.0

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -31,6 +31,9 @@ defmodule Support.Helpers do
       {"class", "inline" <> _} ->
         %{line: 1}
 
+      {"class", "math-" <> _} ->
+        %{line: 1}
+
       _ ->
         %{}
     end


### PR DESCRIPTION
Adds support for mathematical expressions with `$` and `$$`. This is far from standardised, but GitHub now supports math expressions, so I think having an optional extension is justified.

For more context, now that there are more Nx-based packages it's becoming common to write math expressions docs. Math rendering is left to the user (by extending ExDoc), however there are issues if the math is not understood at parser level. For example `$x *y* x` would be parsed as emphasis, hence destroying the original expression. See https://github.com/elixir-lang/ex_doc/issues/1571.

This implementation should match GitHub for the most part. There are tiny differences, for example:

* GitHub parsing has bugs - in the docs they say `\$` should work within expression, but it actually only `\\$` works
* to escape inline math GitHub uses `<span>$</span>`, but EarmarkParses doesn't support inline HTML; and also I don't see a good reason to not support `\$` as with all other delimiters

I looked around and tried to come up with reasonable rules as outlined by the test suite. I also added a note to the docs that this feature is a subject to future changes, it should be fine to do further adjustments as needed, as long as we keep AST compatibility.

As for the AST, I used `<code>` with `.math-inline` and `.math-display`. As far as I can tell, display-style math is generally included within a paragraph (so it's still falls under "inline" parsing). I didn't use `<pre>` for display-style math because `<pre>` is not allowed within `<p>`, but I think that's fine.