### PR TITLE
Add `runtime: false` to `dialyxir` dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule EarmarkParser.MixProject do
 
   @deps [
     {:credo, "~> 1.7.5", only: [:dev]},
-    {:dialyxir, "~> 1.4.1", only: [:dev]},
+    {:dialyxir, "~> 1.4.1", only: [:dev], runtime: false},
     {:earmark_ast_dsl, "~> 0.3.7", only: [:test]},
     {:excoveralls, "~> 0.14.4", only: [:test]},
     {:extractly, "~> 0.5.3", only: [:dev]},


### PR DESCRIPTION
`dialyxir` is meant to be used with `runtime: false` like shown in their README. Otherwise you get this error:

```elixir
Warning: the `dialyxir` application's start function was called, which likely means you                                                                                                                              
did not add the dependency with the `runtime: false` flag. This is not recommended because                                                                                                                           
it will mean that unnecessary applications are started, and unnecessary applications are most                                                                                                                        
likely being added to your PLT file, increasing build time.                                                                                                                                                          
Please add `runtime: false` in your `mix.exs` dependency section e.g.:                                                                                                                                               
{:dialyxir, "~> 0.5", only: [:dev], runtime: false}
```