### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ E.g.
 
 #### Lists
 
-Lists are pretty much GFM compliant, but some behaviors concerning the interpreation of the markdown inside a List Item's first
+Lists are pretty much GFM compliant, but some behaviors concerning the interpretation of the markdown inside a List Item's first
 paragraph seem not worth to be interpreted, examples are blockquote in a tight [list item](ttps://babelmark.github.io/?text=*+aa%0A++%3E+Second)
 which we can only have in a [loose one](https://babelmark.github.io/?text=*+aa%0A++%0A++%3E+Second)
 

--- a/lib/earmark_parser.ex
+++ b/lib/earmark_parser.ex
@@ -357,7 +357,7 @@ defmodule EarmarkParser do
 
   #### Lists
 
-  Lists are pretty much GFM compliant, but some behaviors concerning the interpreation of the markdown inside a List Item's first
+  Lists are pretty much GFM compliant, but some behaviors concerning the interpretation of the markdown inside a List Item's first
   paragraph seem not worth to be interpreted, examples are blockquote in a tight [list item](ttps://babelmark.github.io/?text=*+aa%0A++%3E+Second)
   which we can only have in a [loose one](https://babelmark.github.io/?text=*+aa%0A++%0A++%3E+Second)
 

--- a/lib/earmark_parser/helpers/lookahead_helpers.ex
+++ b/lib/earmark_parser/helpers/lookahead_helpers.ex
@@ -7,7 +7,7 @@ defmodule EarmarkParser.Helpers.LookaheadHelpers do
   @doc """
   Indicates if the _numbered_line_ passed in leaves an inline code block open.
 
-  If so returns a tuple whre the first element is the opening sequence of backticks,
+  If so returns a tuple where the first element is the opening sequence of backticks,
   and the second the linenumber of the _numbered_line_
 
   Otherwise `{nil, 0}` is returned

--- a/lib/earmark_parser/options.ex
+++ b/lib/earmark_parser/options.ex
@@ -129,7 +129,7 @@ defmodule EarmarkParser.Options do
 
   def normalize(options), do: struct(__MODULE__, options) |> normalize()
 
-  defp _deprecate_old_messages(opitons)
+  defp _deprecate_old_messages(options)
   defp _deprecate_old_messages(%__MODULE__{messages: %MapSet{}} = options), do: options
 
   defp _deprecate_old_messages(%__MODULE__{} = options) do

--- a/test/acceptance/ast/diverse_test.exs
+++ b/test/acceptance/ast/diverse_test.exs
@@ -4,7 +4,7 @@ defmodule Acceptance.Ast.DiverseTest do
   import EarmarkAstDsl
 
   describe "etc" do
-    test "entiy" do
+    test "entity" do
       markdown = "`f&ouml;&ouml;`\n"
       ast      = p(tag("code", "f&ouml;&ouml;", [class: "inline"], %{line: 1}))
       messages = []

--- a/test/acceptance/ast/html/block/annotated_block_test.exs
+++ b/test/acceptance/ast/html/block/annotated_block_test.exs
@@ -197,9 +197,9 @@ defmodule Acceptance.Ast.Html.Block.AnnotatedBlockTest do
     end
 
     test "self closing block elements close para but only at BOL, atts do not matter" do
-      markdown = "alpha\ngamma<div class=\"fourty two\"/>beta"
+      markdown = "alpha\ngamma<div class=\"forty two\"/>beta"
       # SIC just do not write that markup
-      ast = [p("alpha\ngamma<div class=\"fourty two\"/>beta")]
+      ast = [p("alpha\ngamma<div class=\"forty two\"/>beta")]
       messages = []
 
       assert as_ast(markdown, annotations: @annotations) == {:ok, ast, messages}
@@ -233,9 +233,9 @@ defmodule Acceptance.Ast.Html.Block.AnnotatedBlockTest do
     end
 
     test "block elements close para but only at BOL, atts do not matter" do
-      markdown = "alpha\ngamma<div class=\"fourty two\"></div>beta"
+      markdown = "alpha\ngamma<div class=\"forty two\"></div>beta"
       # SIC just do not write that markup
-      ast = [p("alpha\ngamma<div class=\"fourty two\"></div>beta")]
+      ast = [p("alpha\ngamma<div class=\"forty two\"></div>beta")]
       messages = []
 
       assert as_ast(markdown, annotations: @annotations) == {:ok, ast, messages}

--- a/test/acceptance/ast/html/block/unannotated_block_test.exs
+++ b/test/acceptance/ast/html/block/unannotated_block_test.exs
@@ -167,9 +167,9 @@ defmodule Acceptance.Ast.Html.Block.UnannotatedBlockTest do
     end
 
     test "self closing block elements close para but only at BOL, atts do not matter" do
-      markdown = "alpha\ngamma<div class=\"fourty two\"/>beta"
+      markdown = "alpha\ngamma<div class=\"forty two\"/>beta"
       # SIC just do not write that markup
-      ast = [p("alpha\ngamma<div class=\"fourty two\"/>beta")]
+      ast = [p("alpha\ngamma<div class=\"forty two\"/>beta")]
       messages = []
 
       assert as_ast(markdown) == {:ok, ast, messages}
@@ -203,9 +203,9 @@ defmodule Acceptance.Ast.Html.Block.UnannotatedBlockTest do
     end
 
     test "block elements close para but only at BOL, atts do not matter" do
-      markdown = "alpha\ngamma<div class=\"fourty two\"></div>beta"
+      markdown = "alpha\ngamma<div class=\"forty two\"></div>beta"
       # SIC just do not write that markup
-      ast = [p("alpha\ngamma<div class=\"fourty two\"></div>beta")]
+      ast = [p("alpha\ngamma<div class=\"forty two\"></div>beta")]
       messages = []
 
       assert as_ast(markdown) == {:ok, ast, messages}

--- a/test/acceptance/ast/line_breaks_test.exs
+++ b/test/acceptance/ast/line_breaks_test.exs
@@ -37,9 +37,9 @@ defmodule Acceptance.Ast.LineBreaksTest do
       assert as_ast(markdown) == {:ok, ast, messages}
     end
     test "only one line" do
-      markdown = "* The lonly  "
+      markdown = "* The lonely  "
       ast      = [
-        ul(li("The lonly  "))
+        ul(li("The lonely  "))
       ]
       messages = []
 

--- a/test/acceptance/ast/links_images/pure_links_test.exs
+++ b/test/acceptance/ast/links_images/pure_links_test.exs
@@ -188,8 +188,8 @@ defmodule Acceptance.Ast.LinksImages.PureLinksTest do
     end
   end
 
-  describe "unicode charecters" do
-    test "support non alpha-numeric unicode charecters" do
+  describe "unicode characters" do
+    test "support non alphanumeric unicode characters" do
       markdown = "http://github.com?foo=😀"
       ast      = p([tag("a", ["http://github.com?foo=😀"], [{"href", "http://github.com?foo=#{URI.encode("😀")}"}])])
       messages = []

--- a/test/acceptance/ast/lists/complex_head_test.exs
+++ b/test/acceptance/ast/lists/complex_head_test.exs
@@ -102,7 +102,7 @@ defmodule Test.Acceptance.Ast.Lists.ComplexHeadTest do
         ul(li(["a", blockquote("b\nc\nd")]))]
       assert ast_from_md(markdown) == expected
     end
-    test "headline with negative indent stop the list/item definitely, but we need to aligne correctly" do
+    test "headline with negative indent stop the list/item definitely, but we need to align correctly" do
       markdown = """
       - a
           ## b

--- a/test/earmark_helpers_tests/link_parser_test.exs
+++ b/test/earmark_helpers_tests/link_parser_test.exs
@@ -20,7 +20,7 @@ defmodule EarmarkParserHelpersTests.LinkParserTest do
     end
 
     test "text part: complex imbrication" do
-      assert parse_link("[pre[iniside]suff]()") == {~s<[pre[iniside]suff]()>, ~s<pre[iniside]suff>, ~s<>, nil, :link}
+      assert parse_link("[pre[inside]suff]()") == {~s<[pre[inside]suff]()>, ~s<pre[inside]suff>, ~s<>, nil, :link}
     end
 
     test "text part: missing closing brackets" do

--- a/test/earmark_helpers_tests/pure_link_helper_test.exs
+++ b/test/earmark_helpers_tests/pure_link_helper_test.exs
@@ -55,7 +55,7 @@ defmodule EarmarkParser.Helpers.TestPureLinkHelpers do
       assert result == expected
     end
 
-    test "invalid charecters should not be part of the link" do
+    test "invalid characters should not be part of the link" do
       #                          0....+....1....+....2....+
       result = convert_pure_link("https://a.link.com<br/>")
       expected = {a( "https://a.link.com", href:  "https://a.link.com"), 18}


### PR DESCRIPTION
Found via `codespell -S deps,RELEASE.md -L crate,symboll` and `typos --hidden --format brief`