### PR TITLE
Resolve single quote string warnings

### DIFF
--- a/test/acceptance/ast/html/permissive_test.exs
+++ b/test/acceptance/ast/html/permissive_test.exs
@@ -27,7 +27,7 @@ defmodule Acceptance.Ast.Html.PermissiveTest do
     # Needs a fix with issue [#326](https://github.com/pragdave/earmark/issues/326)
     test "mixture of tags (was regtest #103)" do 
       markdown = "<x>a\n<y></y>\n<y>\n<z>\n</z>\n<z>\n</x>"
-      ast      = [{"x", '', ["a", "<y></y>", "<y>", "<z>", "</z>", "<z>"], @verbatim}]
+      ast      = [{"x", ~c"", ["a", "<y></y>", "<y>", "<z>", "</z>", "<z>"], @verbatim}]
       messages = Enum.zip([1, 3, 6], ~w[x y z])
                  |> Enum.map(fn {lnb, tag} -> {:warning, lnb, "Failed to find closing <#{tag}>"} end)
 

--- a/test/acceptance/regressions/i002-accept-any-struct-as-option_test.exs
+++ b/test/acceptance/regressions/i002-accept-any-struct-as-option_test.exs
@@ -16,7 +16,7 @@ defmodule MyStruct do
 
     test "or activated" do
       ast =
-        [{"p", '', ["see ", {"a", [{"href", "https://my.site.com"}], ["https://my.site.com"], %{}}], %{}}]
+        [{"p", ~c"", ["see ", {"a", [{"href", "https://my.site.com"}], ["https://my.site.com"], %{}}], %{}}]
 
       assert as_ast(@markdown, %MyStruct{pure_links: true}) == {:ok, ast, []}
     end


### PR DESCRIPTION
This resolves the following errors during tests:

    warning: single-quoted strings represent charlists. Use ~c"" if you
    indeed want a charlist or use "" instead