### PR TITLE
Enable warnings-as-errors in mix test

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -58,7 +58,8 @@ jobs:
         env:
           CC: gcc-10
           CXX: g++-10
-      - run: mix test
+      - run: mix test --warnings-as-errors
+        if: matrix.warnings_as_errors
         env:
           CC: gcc-10
           CXX: g++-10
@@ -67,4 +68,3 @@ jobs:
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support
 # documentation.
-


### PR DESCRIPTION
This supposes to catch those deprecation warnings in Elixir 1.15,16,17 and Erlang/OTP 25,26,27.

Follow-up discussion in https://github.com/RobertDober/earmark_parser/pull/152#issuecomment-2204012602