### PR TITLE
Footnote rendering escapes HTML bug

### DIFF
--- a/lib/earmark_parser/ast/renderer/footnote_renderer.ex
+++ b/lib/earmark_parser/ast/renderer/footnote_renderer.ex
@@ -17,32 +17,35 @@ defmodule EarmarkParser.Ast.Renderer.FootnoteRenderer do
           emit("hr"),
           emit("ol", elements)
         ],
-        class: "footnotes"
+        class: "footnotes flex mt-5 flex-col list-decimal"
       )
 
     prepend(context, ast) |> Message.add_messages(errors)
   end
 
-  defp _render_footnote_def(%Block.FnDef{blocks: blocks, id: id}, {ast, errors, context}=acc) do
+  defp _render_footnote_def(%Block.FnDef{blocks: blocks, id: id}, {ast, errors, context} = acc) do
     if MapSet.member?(context.referenced_footnote_ids, id) do
       context1 = AstRenderer.render(blocks, clear_value(context))
       a_attrs = %{title: "return to article", class: "reversefootnote", href: "#fnref:#{id}"}
+
       footnote_li_ast =
-        emit("li", [emit("a", ["&#x21A9;"], a_attrs) | context1.value],
-         id: "fn:#{id}")
-      {[footnote_li_ast|ast], MapSet.union(errors, context1.options.messages), context}
+        emit("li", [emit("a", ["&#x21A9;"], a_attrs, %{verbatim: true}) | context1.value],
+          id: "fn:#{id}"
+        )
+
+      {[footnote_li_ast | ast], MapSet.union(errors, context1.options.messages), context}
     else
       acc
     end
   end
-
 
   defp render_footnote_blocks(footnotes, context) do
     {elements, errors, _} =
       footnotes
       |> Enum.reduce({[], @empty_set, context}, &_render_footnote_def/2)
 
-    {elements|>Enum.reverse, errors}
+    {elements |> Enum.reverse(), errors}
   end
 end
+
 #  SPDX-License-Identifier: Apache-2.0

--- a/lib/earmark_parser/ast/renderer/footnote_renderer.ex
+++ b/lib/earmark_parser/ast/renderer/footnote_renderer.ex
@@ -17,35 +17,32 @@ defmodule EarmarkParser.Ast.Renderer.FootnoteRenderer do
           emit("hr"),
           emit("ol", elements)
         ],
-        class: "footnotes flex mt-5 flex-col list-decimal"
+        class: "footnotes"
       )
 
     prepend(context, ast) |> Message.add_messages(errors)
   end
 
-  defp _render_footnote_def(%Block.FnDef{blocks: blocks, id: id}, {ast, errors, context} = acc) do
+  defp _render_footnote_def(%Block.FnDef{blocks: blocks, id: id}, {ast, errors, context}=acc) do
     if MapSet.member?(context.referenced_footnote_ids, id) do
       context1 = AstRenderer.render(blocks, clear_value(context))
       a_attrs = %{title: "return to article", class: "reversefootnote", href: "#fnref:#{id}"}
-
       footnote_li_ast =
-        emit("li", [emit("a", ["&#x21A9;"], a_attrs, %{verbatim: true}) | context1.value],
-          id: "fn:#{id}"
-        )
-
-      {[footnote_li_ast | ast], MapSet.union(errors, context1.options.messages), context}
+        emit("li", [emit("a", ["&#x21A9;"], a_attrs) | context1.value],
+         id: "fn:#{id}")
+      {[footnote_li_ast|ast], MapSet.union(errors, context1.options.messages), context}
     else
       acc
     end
   end
+
 
   defp render_footnote_blocks(footnotes, context) do
     {elements, errors, _} =
       footnotes
       |> Enum.reduce({[], @empty_set, context}, &_render_footnote_def/2)
 
-    {elements |> Enum.reverse(), errors}
+    {elements|>Enum.reverse, errors}
   end
 end
-
 #  SPDX-License-Identifier: Apache-2.0

--- a/lib/earmark_parser/ast/renderer/footnote_renderer.ex
+++ b/lib/earmark_parser/ast/renderer/footnote_renderer.ex
@@ -28,7 +28,7 @@ defmodule EarmarkParser.Ast.Renderer.FootnoteRenderer do
       context1 = AstRenderer.render(blocks, clear_value(context))
       a_attrs = %{title: "return to article", class: "reversefootnote", href: "#fnref:#{id}"}
       footnote_li_ast =
-        emit("li", [emit("a", ["&#x21A9;"], a_attrs) | context1.value],
+        emit("li", [emit("a", ["&#x21A9;"], a_attrs, %{verbatim: true}) | context1.value],
          id: "fn:#{id}")
       {[footnote_li_ast|ast], MapSet.union(errors, context1.options.messages), context}
     else

--- a/test/acceptance/ast/footnotes/fn_in_lists_test.exs
+++ b/test/acceptance/ast/footnotes/fn_in_lists_test.exs
@@ -45,26 +45,6 @@ defmodule Test.Acceptance.Ast.Footnotes.FnInListsTest do
       - Footnote 2.2
       """
 
-      ast = [
-        ul(
-          li([
-            "A line with",
-            footnote(1),
-            " two references",
-            footnote(2)
-          ])
-        ),
-        footnotes([
-          footnote_def(1, p(["Footnote ", tag("strong", "one")])),
-          footnote_def(2, [
-            tag("ul", [
-              tag("li", "Footnote 2.1"),
-              tag("li", "Footnote 2.2")
-            ])
-          ])
-        ])
-      ]
-
       {:ok, result_ast, []} = as_ast(markdown, footnotes: true)
       has_verbatim?(result_ast)
     end

--- a/test/acceptance/ast/footnotes/fn_in_lists_test.exs
+++ b/test/acceptance/ast/footnotes/fn_in_lists_test.exs
@@ -36,6 +36,39 @@ defmodule Test.Acceptance.Ast.Footnotes.FnInListsTest do
       assert_asts_are_equal(result_ast, ast)
     end
 
+    test "footer list has verbatim" do
+      markdown = """
+      - A line with[^1] two references[^2]
+
+      [^1]: Footnote **one**
+      [^2]: - Footnote 2.1
+      - Footnote 2.2
+      """
+
+      ast = [
+        ul(
+          li([
+            "A line with",
+            footnote(1),
+            " two references",
+            footnote(2)
+          ])
+        ),
+        footnotes([
+          footnote_def(1, p(["Footnote ", tag("strong", "one")])),
+          footnote_def(2, [
+            tag("ul", [
+              tag("li", "Footnote 2.1"),
+              tag("li", "Footnote 2.2")
+            ])
+          ])
+        ])
+      ]
+
+      {:ok, result_ast, []} = as_ast(markdown, footnotes: true)
+      has_verbatim?(result_ast)
+    end
+
     test "list body, first is not referenced" do
       markdown = """
       - N.B.

--- a/test/acceptance/ast/footnotes/single_footnote_test.exs
+++ b/test/acceptance/ast/footnotes/single_footnote_test.exs
@@ -108,22 +108,6 @@ defmodule Acceptance.Ast.Footnotes.SingleFootnoteTest do
       [^1]: which [is a link](http://to.some.site)
       """
 
-      ast = [
-        p([
-          "here is my footnote",
-          footnote(1)
-        ]),
-        footnotes(
-          footnote_def(
-            1,
-            p([
-              "which ",
-              a("is a link", href: "http://to.some.site")
-            ])
-          )
-        )
-      ]
-
       {:ok, result_ast, []} = as_ast(markdown, footnotes: true, pure_links: true)
       has_verbatim?(result_ast)
     end

--- a/test/acceptance/ast/footnotes/single_footnote_test.exs
+++ b/test/acceptance/ast/footnotes/single_footnote_test.exs
@@ -101,6 +101,33 @@ defmodule Acceptance.Ast.Footnotes.SingleFootnoteTest do
       assert_asts_are_equal(result_ast, ast)
     end
 
+    test "footnote has verbatim" do
+      markdown = """
+      here is my footnote[^1]
+
+      [^1]: which [is a link](http://to.some.site)
+      """
+
+      ast = [
+        p([
+          "here is my footnote",
+          footnote(1)
+        ]),
+        footnotes(
+          footnote_def(
+            1,
+            p([
+              "which ",
+              a("is a link", href: "http://to.some.site")
+            ])
+          )
+        )
+      ]
+
+      {:ok, result_ast, []} = as_ast(markdown, footnotes: true, pure_links: true)
+      has_verbatim?(result_ast)
+    end
+
     test "A two line footnote" do
       markdown = """
       here is my footnote[^1]

--- a/test/support/footnote_helpers.ex
+++ b/test/support/footnote_helpers.ex
@@ -8,9 +8,11 @@ defmodule Support.FootnoteHelpers do
   end
 
   def footnote_def(number, content)
+
   def footnote_def(number, content) when is_tuple(content) do
     footnote_def(number, [content])
   end
+
   def footnote_def(number, content) do
     tag("li", [reverse_footnote(number) | content], id: "fn:#{number}")
   end
@@ -34,6 +36,30 @@ defmodule Support.FootnoteHelpers do
       href: "#fnref:#{number}",
       title: "return to article"
     )
+  end
+
+  def has_verbatim?(ast) do
+    case ast do
+      [
+        _,
+        {"div", [{"class", "footnotes"}],
+         [
+           _,
+           {"ol", [],
+            [
+              {"li", [_],
+               [
+                 {"a", [_, _, {"href", _}], ["&#x21A9;"], %{verbatim: true}},
+                 _
+               ], %{}}
+            ], %{}}
+         ], %{}}
+      ] ->
+        true
+
+      _ ->
+        false
+    end
   end
 end
 


### PR DESCRIPTION
Updated the rendering logic to ensure HTML content is properly rendered instead of being escaped as a string.

Added test cases to verify that %{verbatim: true} is included. 


Fixes https://github.com/elixir-lang/ex_doc/issues/1452
