### PR TITLE
Fix rendering of multiple images with reflinks

### DIFF
--- a/lib/earmark_parser/ast/inline.ex
+++ b/lib/earmark_parser/ast/inline.ex
@@ -136,7 +136,7 @@ defmodule EarmarkParser.Ast.Inline do
     end
   end
 
-  @link_text ~S{(?:\[[^]]*\]|[^][]|\])*}
+  @link_text ~S{(?:\[[^]]*\]|[^][])*}
 
   def converter_for_reflink({src, lnb, context, use_linky?}) do
     if use_linky? do

--- a/test/acceptance/ast/reflink_test.exs
+++ b/test/acceptance/ast/reflink_test.exs
@@ -76,7 +76,7 @@ defmodule Acceptance.Ast.ReflinkTest do
 
     test "not so simple case" do
       markdown = "[[]]]text] [reference]\n[reference]: some_url"
-      html = "<p><a href=\"some_url\" title=\"\">[]]]text</a></p>\n"
+      html = "<p>[[]]]text] <a href=\"some_url\" title=\"\">reference</a></p>\n"
       ast = parse_html(html)
       messages = []
 

--- a/test/acceptance/bug_test/linked_images_test.exs
+++ b/test/acceptance/bug_test/linked_images_test.exs
@@ -1,0 +1,68 @@
+defmodule Acceptance.BugTest.LinkedImagesTest do
+  use ExUnit.Case, async: true
+  import Support.Helpers, only: [as_ast: 1]
+  import EarmarkAstDsl, only: [p: 1, tag: 3]
+
+  test "consecutive reference-style linked images" do
+    markdown = """
+    [![Badge 1][img1]][url1] [![Badge 2][img2]][url2]
+
+    [img1]: https://google.com/logo.png
+    [img2]: https://yahoo.com/logo.png
+    [url1]: https://google.com
+    [url2]: https://yahoo.com
+    """
+
+    expected_ast = [
+      p([
+        tag("a", [tag("img", [], src: "https://google.com/logo.png", alt: "Badge 1", title: "")],
+          href: "https://google.com",
+          title: ""
+        ),
+        " ",
+        tag("a", [tag("img", [], src: "https://yahoo.com/logo.png", alt: "Badge 2", title: "")],
+          href: "https://yahoo.com",
+          title: ""
+        )
+      ])
+    ]
+
+    assert as_ast(markdown) == {:ok, expected_ast, []}
+  end
+
+  test "single reference-style linked image" do
+    markdown = """
+    [![Badge 1][img1]][url1]
+
+    [img1]: https://google.com/logo.png
+    [url1]: https://google.com
+    """
+
+    expected_ast = [
+      p([
+        tag("a", [tag("img", [], src: "https://google.com/logo.png", alt: "Badge 1", title: "")],
+          href: "https://google.com",
+          title: ""
+        )
+      ])
+    ]
+
+    assert as_ast(markdown) == {:ok, expected_ast, []}
+  end
+
+  test "normal multiple images" do
+    markdown = """
+    [![Badge 1](https://google.com/logo.png)](https://google.com) [![Badge 2](https://yahoo.com/logo.png)](https://yahoo.com)
+    """
+
+    expected_ast = [
+      p([
+        tag("a", [tag("img", [], src: "https://google.com/logo.png", alt: "Badge 1")], href: "https://google.com"),
+        " ",
+        tag("a", [tag("img", [], src: "https://yahoo.com/logo.png", alt: "Badge 2")], href: "https://yahoo.com")
+      ])
+    ]
+
+    assert as_ast(markdown) == {:ok, expected_ast, []}
+  end
+end


### PR DESCRIPTION
Fixes #120 and #149 

There is one test case (`[[]]]text] [reference]\n[reference]: some_url`) that did not have the right expectation. I have changes that test to reflect what Github markdown does but please let me know if this is wrong.