### PR TITLE
I169 trying nimble parsec

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,3 +1,14 @@
+locals_without_parens = [
+  defparsec: 2,
+  defparsec: 3,
+  defparsecp: 2,
+  defparsecp: 3,
+  defcombinator: 2,
+  defcombinator: 3,
+  defcombinatorp: 2,
+  defcombinatorp: 3
+]
+
 [
   force_do_end_blocks: true,
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],

--- a/lib/earmark_parser/nimble_parsers.ex
+++ b/lib/earmark_parser/nimble_parsers.ex
@@ -4,6 +4,6 @@ defmodule EarmarkParser.NimbleParsers do
   """
 
   defdelegate parse_html_atts(input), to: __MODULE__.HtmlAttsParser
-
 end
+
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/earmark_parser/nimble_parsers.ex
+++ b/lib/earmark_parser/nimble_parsers.ex
@@ -1,0 +1,9 @@
+defmodule EarmarkParser.NimbleParsers do
+  @moduledoc ~S"""
+  coming soon
+  """
+
+  defdelegate parse_html_atts(input), to: __MODULE__.HtmlAttsParser
+
+end
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/earmark_parser/nimble_parsers/html_atts_parser.ex
+++ b/lib/earmark_parser/nimble_parsers/html_atts_parser.ex
@@ -4,10 +4,48 @@ defmodule EarmarkParser.NimbleParsers.HtmlAttsParser do
   """
   import NimbleParsec
 
-  end_html_att =
-    ignore(ascii_char([?>..?>]))
+  string_value =
+    ascii_char([?"])
+    |> ignore()
+    |> repeat(
+      lookahead_not(ascii_char([?"]))
+      |> choice([
+        ~S(\") |> string() |> replace(?"),
+        utf8_char([])
+      ])
+    )
+    |> ignore(ascii_char([?"]))
 
-  defparsec(:parse_html_atts, end_html_att)
+  html_att_name =
+    ascii_string([?a..?z, ?A..?z, ?-..?-], min: 1)
+
+  html_att =
+    html_att_name
+    |> choice([
+      "=" |> string() |> ignore() |> concat(string_value),
+      empty()
+    ])
+    |> reduce(:reduce_att)
+
+  html_att_end =
+    string(">")
+
+  html_atts =
+    html_att
+    |> repeat(" " |> string() |> times(min: 1) |> ignore() |> concat(html_att))
+
+  defparsec(:parse_html_atts, html_atts |> optional() |> ignore(html_att_end))
+
+  @doc false
+  def reduce_att(att_ast)
+
+  def reduce_att([name]) do
+    {name, true}
+  end
+
+  def reduce_att([name | values]) do
+    {name, IO.chardata_to_string(values)}
+  end
 end
 
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/earmark_parser/nimble_parsers/html_atts_parser.ex
+++ b/lib/earmark_parser/nimble_parsers/html_atts_parser.ex
@@ -3,18 +3,7 @@ defmodule EarmarkParser.NimbleParsers.HtmlAttsParser do
   Parses an HTML tag
   """
   import NimbleParsec
-
-  string_value =
-    ascii_char([?"])
-    |> ignore()
-    |> repeat(
-      lookahead_not(ascii_char([?"]))
-      |> choice([
-        ~S(\") |> string() |> replace(?"),
-        utf8_char([])
-      ])
-    )
-    |> ignore(ascii_char([?"]))
+  alias EarmarkParser.NimbleParsers.StringParser
 
   html_att_name =
     ascii_string([?a..?z, ?A..?z, ?-..?-], min: 1)
@@ -22,7 +11,7 @@ defmodule EarmarkParser.NimbleParsers.HtmlAttsParser do
   html_att =
     html_att_name
     |> choice([
-      "=" |> string() |> ignore() |> concat(string_value),
+      "=" |> string() |> ignore() |> parsec({StringParser, :string_value}),
       empty()
     ])
     |> reduce(:reduce_att)

--- a/lib/earmark_parser/nimble_parsers/html_atts_parser.ex
+++ b/lib/earmark_parser/nimble_parsers/html_atts_parser.ex
@@ -1,0 +1,13 @@
+defmodule EarmarkParser.NimbleParsers.HtmlAttsParser do
+  @moduledoc ~S"""
+  Parses an HTML tag
+  """
+  import NimbleParsec
+
+  end_html_att =
+    ignore(ascii_char([?>..?>]))
+
+  defparsec(:parse_html_atts, end_html_att)
+end
+
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/earmark_parser/nimble_parsers/html_tag_parser.ex
+++ b/lib/earmark_parser/nimble_parsers/html_tag_parser.ex
@@ -1,0 +1,10 @@
+defmodule EarmarkParser.NimbleParsers.HtmlTagParser do
+
+  @moduledoc ~S"""
+  Parses an HTML tag
+  """
+  import NimbleParsec
+  alias EarmarkParser.NimbleParsers.HtmlAttsParser
+  
+end
+# SPDX-License-Identifier: Apache-2.0

--- a/lib/earmark_parser/nimble_parsers/string_parser.ex
+++ b/lib/earmark_parser/nimble_parsers/string_parser.ex
@@ -1,0 +1,23 @@
+defmodule EarmarkParser.NimbleParsers.StringParser do
+  @moduledoc ~S"""
+  String combinator
+  """
+
+  import NimbleParsec
+
+  defcombinator(
+    :string_value,
+    ascii_char([?"])
+    |> ignore()
+    |> repeat(
+      lookahead_not(ascii_char([?"]))
+      |> choice([
+        ~S(\") |> string() |> replace(?"),
+        utf8_char([])
+      ])
+    )
+    |> ignore(ascii_char([?"]))
+  )
+end
+
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/earmark_parser/options.ex
+++ b/lib/earmark_parser/options.ex
@@ -104,8 +104,8 @@ defmodule EarmarkParser.Options do
   Use normalize before passing it into any API function
 
         iex(1)> options = normalize(annotations: "%%")
-        ...(1)> options.annotations
-        ~r{\A(.*)(%%.*)}
+        ...(1)> options.annotations.source
+        "\\A(.*)(%%.*)"
   """
   @spec normalize(t() | keyword()) :: t()
   def normalize(options)

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule EarmarkParser.MixProject do
     {:earmark_ast_dsl, "~> 0.3.7", only: [:test]},
     {:excoveralls, "~> 0.18.3", only: [:test]},
     {:extractly, "~> 0.5.3", only: [:dev]},
-    {:floki, "~> 0.36", only: [:dev, :test]},
+    {:floki, "~> 0.36", only: [:dev, :test]}
   ]
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -1,17 +1,21 @@
 defmodule EarmarkParser.MixProject do
   use Mix.Project
 
-  @version "1.4.44"
+  @version "1.4.45"
   @url "https://github.com/RobertDober/earmark_parser"
 
   @deps [
+    # production environnement
+    {:nimble_parsec, "~> 1.4.2", runtime: false},
+
+    # dev and test environnements
     {:benchee, "~> 1.3.1", only: [:dev]},
     # {:credo, "~> 1.7.5", only: [:dev]},
     {:dialyxir, "~> 1.4.5", only: [:dev], runtime: false},
     {:earmark_ast_dsl, "~> 0.3.7", only: [:test]},
     {:excoveralls, "~> 0.18.3", only: [:test]},
     {:extractly, "~> 0.5.3", only: [:dev]},
-    {:floki, "~> 0.36", only: [:dev, :test]}
+    {:floki, "~> 0.36", only: [:dev, :test]},
   ]
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -18,6 +18,17 @@ defmodule EarmarkParser.MixProject do
     {:floki, "~> 0.36", only: [:dev, :test]}
   ]
 
+  def cli do
+    [
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ]
+    ]
+  end
+
   def project do
     [
       app: :earmark_parser,
@@ -28,12 +39,6 @@ defmodule EarmarkParser.MixProject do
       deps: @deps,
       description: "AST parser and generator for Markdown",
       package: package(),
-      preferred_cli_env: [
-        coveralls: :test,
-        "coveralls.detail": :test,
-        "coveralls.post": :test,
-        "coveralls.html": :test
-      ],
       test_coverage: [tool: ExCoveralls],
       aliases: [docs: &build_docs/1]
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -20,12 +20,6 @@ defmodule EarmarkParser.MixProject do
 
   def cli do
     [
-      preferred_cli_env: [
-        coveralls: :test,
-        "coveralls.detail": :test,
-        "coveralls.post": :test,
-        "coveralls.html": :test
-      ]
     ]
   end
 
@@ -39,6 +33,12 @@ defmodule EarmarkParser.MixProject do
       deps: @deps,
       description: "AST parser and generator for Markdown",
       package: package(),
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ],
       test_coverage: [tool: ExCoveralls],
       aliases: [docs: &build_docs/1]
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -17,6 +17,7 @@
   "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "statistex": {:hex, :statistex, "1.0.0", "f3dc93f3c0c6c92e5f291704cf62b99b553253d7969e9a5fa713e5481cd858a5", [:mix], [], "hexpm", "ff9d8bee7035028ab4742ff52fc80a2aa35cece833cf5319009b52f1b5a86c27"},

--- a/test/nimble_parsers/html_att_test.exs
+++ b/test/nimble_parsers/html_att_test.exs
@@ -9,7 +9,26 @@ defmodule Test.NimbleParsers.HtmlAttTest do
 
     test "does not parse an empty string" do
       parse_html_atts("")
-      |> parsed_error("expected ASCII character in the range \">\" to \">\"")
+      |> parsed_error("expected string \">\"")
+    end
+  end
+
+  describe "boolean attribute" do
+    test "just it's presence" do
+      parse_html_atts("hidden>")
+      |> parsed_ok([{"hidden", true}])
+    end
+
+    test "two boolean attributes" do
+      parse_html_atts("hidden and-visible>")
+      |> parsed_ok([{"hidden", true}, {"and-visible", true}])
+    end
+  end
+
+  describe "a string attribute" do
+    test "elixir, what else?" do
+      parse_html_atts(~S{lang="elixir">})
+      |> parsed_ok([{"lang", "elixir"}])
     end
   end
 end

--- a/test/nimble_parsers/html_att_test.exs
+++ b/test/nimble_parsers/html_att_test.exs
@@ -30,6 +30,20 @@ defmodule Test.NimbleParsers.HtmlAttTest do
       parse_html_atts(~S{lang="elixir">})
       |> parsed_ok([{"lang", "elixir"}])
     end
+
+    test "escaped double quote" do
+      parse_html_atts(~S{lang="\"lua\"">})
+      |> parsed_ok([{"lang", "\"lua\""}])
+    end
+
+    test "single quoted string too" do
+      parse_html_atts(~S{lang="\"pt-br\"" lang='fr-fr' lang='de-\'at\''>})
+      |> parsed_ok([
+        {"lang", "\"pt-br\""},
+        {"lang", "fr-fr"},
+        {"lang", "de-'at'"}
+      ])
+    end
   end
 end
 

--- a/test/nimble_parsers/html_att_test.exs
+++ b/test/nimble_parsers/html_att_test.exs
@@ -1,0 +1,17 @@
+defmodule Test.NimbleParsers.HtmlAttTest do
+  use Support.NimbleTestCase
+
+  describe "empty att list" do
+    test "returns an empty list if end char (>) is present" do
+      parse_html_atts(">")
+      |> parsed_ok([])
+    end
+
+    test "does not parse an empty string" do
+      parse_html_atts("")
+      |> parsed_error("expected ASCII character in the range \">\" to \">\"")
+    end
+  end
+end
+
+# SPDX-License-Identifier: Apache-2.0

--- a/test/nimble_parsers/html_oneline_tag_test.exs
+++ b/test/nimble_parsers/html_oneline_tag_test.exs
@@ -1,0 +1,13 @@
+defmodule Test.NimbleParsers.HtmlOnelineTagTest do
+
+  use Support.NimbleTestCase
+
+  describe "no attributes" do
+    test "br" do
+      # parse_html_tag("<br/>")
+      # |> parsed_ok({"br", [], [], %{verbatim: true}})
+    end
+  end
+  
+end
+# SPDX-License-Identifier: Apache-2.0

--- a/test/support/nimble_test_case.ex
+++ b/test/support/nimble_test_case.ex
@@ -1,0 +1,13 @@
+defmodule Support.NimbleTestCase do
+  defmacro __using__(_options) do
+    quote do
+      use ExUnit.Case, async: true
+
+      import EarmarkParser.NimbleParsers
+      import Support.NimbleTests
+
+    end
+  end
+end
+
+# SPDX-License-Identifier: Apache-2.0

--- a/test/support/nimble_test_case.ex
+++ b/test/support/nimble_test_case.ex
@@ -5,7 +5,6 @@ defmodule Support.NimbleTestCase do
 
       import EarmarkParser.NimbleParsers
       import Support.NimbleTests
-
     end
   end
 end

--- a/test/support/nimble_tests.ex
+++ b/test/support/nimble_tests.ex
@@ -1,0 +1,19 @@
+defmodule Support.NimbleTests do
+  @moduledoc ~S"""
+  Makes asserting on NimbleParsec results simpler
+  """
+  defmacro parsed_error(parsed, expected) do
+    quote do
+    {:error, message, _, _, _, _} = unquote(parsed) # |> IO.inspect() 
+      assert message == unquote(expected)
+    end
+  end
+
+  defmacro parsed_ok(parsed, expected) do
+    quote do
+    {:ok, result, _, _, _, _} = unquote(parsed) # |> IO.inspect() 
+      assert result == unquote(expected)
+    end
+  end
+end
+# SPDX-License-Identifier: Apache-2.0

--- a/test/support/nimble_tests.ex
+++ b/test/support/nimble_tests.ex
@@ -4,16 +4,19 @@ defmodule Support.NimbleTests do
   """
   defmacro parsed_error(parsed, expected) do
     quote do
-    {:error, message, _, _, _, _} = unquote(parsed) # |> IO.inspect() 
+      # |> IO.inspect() 
+      {:error, message, _, _, _, _} = unquote(parsed)
       assert message == unquote(expected)
     end
   end
 
   defmacro parsed_ok(parsed, expected) do
     quote do
-    {:ok, result, _, _, _, _} = unquote(parsed) # |> IO.inspect() 
+      # |> IO.inspect() 
+      {:ok, result, _, _, _, _} = unquote(parsed)
       assert result == unquote(expected)
     end
   end
 end
+
 # SPDX-License-Identifier: Apache-2.0

--- a/test/support/nimble_tests.ex
+++ b/test/support/nimble_tests.ex
@@ -4,7 +4,7 @@ defmodule Support.NimbleTests do
   """
   defmacro parsed_error(parsed, expected) do
     quote do
-      # |> IO.inspect() 
+      # |> IO.inspect()
       {:error, message, _, _, _, _} = unquote(parsed)
       assert message == unquote(expected)
     end
@@ -12,7 +12,7 @@ defmodule Support.NimbleTests do
 
   defmacro parsed_ok(parsed, expected) do
     quote do
-      # |> IO.inspect() 
+      # |> IO.inspect()
       {:ok, result, _, _, _, _} = unquote(parsed)
       assert result == unquote(expected)
     end


### PR DESCRIPTION
@bradhanks 
So I was kind of shocked that I was too stupid to use NimbleParsec, therefore I tried again ;)

Seriously now, I would be interested in what you think about NimbleParsec. I am well aware that this still tiny code does not address the many challanges we would have in trying to integrate NimbleParsec into EarmarkParser

1. How to refactor for better readability
2. How to create helpers to not repeat things like ` " " |> string() |> times(min: 1) |> ignore() `
3. How to feed enough lines into NimbleParsec, probably not really possible, thusly we need to join the rest of the lines, pass it into the HTML parser, and resplit and retokenize the rest, which would probably invalidate the "split the whole document into lines at first" approach (which I never really liked).

    We could probably already now just tokenize each line on demand, like creating a stream of lines by advancing to each `/\n\r?/` when needed (would optimize inline code parsing too)